### PR TITLE
(fix) Fix the issue of PG driver isolation conflicts

### DIFF
--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/DsPluginInfo.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/DsPluginInfo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.clougence.clouddm.platform.plugin;
 
 import java.util.List;

--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/DsPluginInfo.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/DsPluginInfo.java
@@ -18,8 +18,8 @@ package com.clougence.clouddm.platform.plugin;
 import java.util.List;
 
 import com.clougence.clouddm.base.metadata.ds.DataSourceType;
+import com.clougence.clouddm.platform.plugin.info.LeasedDsFactory;
 import com.clougence.clouddm.sdk.execute.session.SessionFactory;
-import com.clougence.drivers.DsFactory;
 import com.clougence.schema.dialect.Dialect;
 import com.clougence.schema.editor.provider.SqlBuilder;
 
@@ -35,7 +35,7 @@ public interface DsPluginInfo extends PluginInfo {
 
     //
 
-    DsFactory<?> createDriver(String driverFamily, String driverVer) throws Exception;
+    LeasedDsFactory<?> createDriver(String driverFamily, String driverVer) throws Exception;
 
     SessionFactory<?> createSessionFactory(String driverFamily, String driverVer) throws Exception;
 }

--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/PluginInfo.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/PluginInfo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.clougence.clouddm.platform.plugin;
 
 import java.util.List;

--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/PluginLoadHelper.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/PluginLoadHelper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.clougence.clouddm.platform.plugin;
 
 import java.io.File;

--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/PluginManager.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/PluginManager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.clougence.clouddm.platform.plugin;
 
 import java.io.File;

--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/BaseMeta.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/BaseMeta.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.clougence.clouddm.platform.plugin.info;
 
 import java.util.List;

--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/DsDriverBindingHolder.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/DsDriverBindingHolder.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.clougence.clouddm.platform.plugin.info;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.clougence.clouddm.sdk.execute.session.SessionFactory;
+import com.clougence.drivers.DriverBinding;
+import com.clougence.drivers.DsFactory;
+
+final class DsDriverBindingHolder {
+
+    private final String        key;
+    private DriverBinding       binding;
+    private DsFactory<?>        driverFactory;
+    private SessionFactory<?>   sessionFactory;
+    private final AtomicInteger refCount = new AtomicInteger();
+    private final AtomicBoolean retired  = new AtomicBoolean();
+
+    public DsDriverBindingHolder(String key, DriverBinding binding){
+        this.key = key;
+        this.binding = binding;
+    }
+
+    public synchronized DsFactory<?> getOrCreateDriverFactory(String dsFactoryName) throws Exception {
+        if (this.driverFactory != null) {
+            return this.driverFactory;
+        }
+
+        DriverBinding currentBinding = requireBinding();
+        Class<?> factoryType = currentBinding.asClassLoader().loadClass(dsFactoryName);
+        if (!DsFactory.class.isAssignableFrom(factoryType)) {
+            throw new IllegalStateException(dsFactoryName + " is not a DsFactory, driverVersion='" + this.key + "'.");
+        }
+
+        this.driverFactory = (DsFactory<?>) factoryType.getDeclaredConstructor().newInstance();
+        return this.driverFactory;
+    }
+
+    public synchronized SessionFactory<?> getOrCreateSessionFactory(String sessionFactoryName) throws Exception {
+        if (this.sessionFactory != null) {
+            return this.sessionFactory;
+        }
+
+        DriverBinding currentBinding = requireBinding();
+        Class<?> sessionFactoryType = currentBinding.asClassLoader().loadClass(sessionFactoryName);
+        if (!SessionFactory.class.isAssignableFrom(sessionFactoryType)) {
+            throw new IllegalStateException(sessionFactoryName + " is not a SessionFactory, driverVersion='" + this.key + "'.");
+        }
+
+        this.sessionFactory = (SessionFactory<?>) sessionFactoryType.getDeclaredConstructor().newInstance();
+        return this.sessionFactory;
+    }
+
+    public void retain() {
+        this.refCount.incrementAndGet();
+    }
+
+    public void retire() {
+        this.retired.set(true);
+        tryCleanup();
+    }
+
+    public boolean isExpired() {
+        DriverBinding currentBinding = this.binding;
+        return currentBinding == null || currentBinding.isExpired();
+    }
+
+    void release() {
+        int current = this.refCount.decrementAndGet();
+        if (current < 0) {
+            this.refCount.incrementAndGet();
+            throw new IllegalStateException("driver binding refCount is negative, driverVersion='" + this.key + "'.");
+        }
+        tryCleanup();
+    }
+
+    private synchronized void tryCleanup() {
+        if (!this.retired.get() || this.refCount.get() > 0) {
+            return;
+        }
+
+        this.driverFactory = null;
+        this.sessionFactory = null;
+        this.binding = null;
+    }
+
+    private DriverBinding requireBinding() {
+        DriverBinding currentBinding = this.binding;
+        if (currentBinding == null) {
+            throw new IllegalStateException("driver binding has been cleaned, driverVersion='" + this.key + "'.");
+        }
+        return currentBinding;
+    }
+
+}

--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/DsMeta.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/DsMeta.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.clougence.clouddm.platform.plugin.info;
 
 import java.io.IOException;
@@ -9,10 +24,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import com.clougence.clouddm.base.metadata.ds.DataSourceConfig;
 import com.clougence.clouddm.base.metadata.ds.DataSourceType;
 import com.clougence.clouddm.platform.plugin.DsPluginInfo;
 import com.clougence.clouddm.platform.plugin.PluginManager;
 import com.clougence.clouddm.sdk.Spi;
+import com.clougence.clouddm.sdk.execute.resource.DsResourceManager;
+import com.clougence.clouddm.sdk.execute.session.Session;
+import com.clougence.clouddm.sdk.execute.session.SessionContextDTO;
 import com.clougence.clouddm.sdk.execute.session.SessionFactory;
 import com.clougence.drivers.DriverBinding;
 import com.clougence.drivers.DriverVersion;
@@ -26,18 +45,16 @@ import com.clougence.utils.reflect.Annotation;
 
 public class DsMeta extends BaseMeta implements DsPluginInfo {
 
-    private final Map<Class<?>, Map<String, Spi>> dsSpiMap;
-    private final I18nUtils                       dsI18nUtil;
-    private final Map<String, Object>             dsFeatures;
-    private final DataSourceType                  dsType;
-    private String                                dsSessionFactory;
-    private SqlBuilder                            dsSqlBuilder;
-    private Dialect                               dsDialect;
-    private List<String>                          dsDriverFamily;
+    private final Map<Class<?>, Map<String, Spi>>    dsSpiMap;
+    private final I18nUtils                          dsI18nUtil;
+    private final Map<String, Object>                dsFeatures;
+    private final DataSourceType                     dsType;
+    private String                                   dsSessionFactory;
+    private SqlBuilder                               dsSqlBuilder;
+    private Dialect                                  dsDialect;
+    private List<String>                             dsDriverFamily;
     //
-    private final Map<String, DriverBinding>      driverBindingCache  = new ConcurrentHashMap<>();
-    private final Map<String, DsFactory<?>>       driverFactoryCache  = new ConcurrentHashMap<>();
-    private final Map<String, SessionFactory<?>>  sessionFactoryCache = new ConcurrentHashMap<>();
+    private final Map<String, DsDriverBindingHolder> driverBindingCache = new ConcurrentHashMap<>();
 
     public DsMeta(String pluginClass, Annotation pluginInfo, GlobalMeta globalMeta, LoadDef loadDef) throws IOException{
         super(pluginClass, pluginInfo, globalMeta, loadDef);
@@ -132,77 +149,54 @@ public class DsMeta extends BaseMeta implements DsPluginInfo {
     //
 
     @Override
-    public DsFactory<?> createDriver(String driverFamily, String driverVer) throws Exception {
+    public LeasedDsFactory<?> createDriver(String driverFamily, String driverVer) throws Exception {
         String key = buildDriverKey(driverFamily, driverVer);
-        ensureDriverCaches(driverFamily, driverVer, key);
-        DsFactory<?> cached = this.driverFactoryCache.get(key);
-        if (cached != null) {
-            return cached;
+        DsDriverBindingHolder holder = findBinding(driverFamily, driverVer, key);
+        DriverVersion ver = findDriverVersion(driverFamily, driverVer, key);
+        String dsFactoryName = StringUtils.trimToNull(ver.getDsFactory());
+        if (dsFactoryName == null) {
+            throw new UnsupportedOperationException("no driver dsFactory configured for '" + key + "'.");
         }
 
-        synchronized (this.driverFactoryCache) {
-            cached = this.driverFactoryCache.get(key);
-            if (cached != null) {
-                return cached;
-            }
-
-            DriverVersion driverVersion = PluginManager.driverLoader().findDriver(driverFamily, driverVer);
-            if (driverVersion == null) {
-                throw new UnsupportedOperationException("no driver metadata for '" + key + "'.");
-            }
-
-            String dsFactoryName = StringUtils.trimToNull(driverVersion.getDsFactory());
-            if (dsFactoryName == null) {
-                throw new UnsupportedOperationException("no driver dsFactory configured for '" + key + "'.");
-            }
-
-            DriverBinding binding = findBinding(driverFamily, driverVer, key);
-            Class<?> factoryType = binding.asClassLoader().loadClass(dsFactoryName);
-            if (!DsFactory.class.isAssignableFrom(factoryType)) {
-                throw new IllegalStateException(dsFactoryName + " is not a DsFactory, driverVersion='" + key + "'.");
-            }
-
-            cached = (DsFactory<?>) factoryType.getDeclaredConstructor().newInstance();
-            this.driverFactoryCache.put(key, cached);
-            return cached;
-        }
+        DsFactory<?> dsFactory = holder.getOrCreateDriverFactory(dsFactoryName);
+        return new LeasedDsFactory<>(holder, dsFactory);
     }
 
     @Override
     public SessionFactory<?> createSessionFactory(String driverFamily, String driverVer) throws Exception {
         String key = buildDriverKey(driverFamily, driverVer);
-        ensureDriverCaches(driverFamily, driverVer, key);
-        SessionFactory<?> cached = this.sessionFactoryCache.get(key);
-        if (cached != null) {
-            return cached;
+        findDriverVersion(driverFamily, driverVer, key);
+        String sessionFactoryName = StringUtils.trimToNull(this.dsSessionFactory);
+        if (sessionFactoryName == null) {
+            throw new UnsupportedOperationException("no sessionFactory configured for '" + key + "'.");
         }
 
-        synchronized (this.sessionFactoryCache) {
-            cached = this.sessionFactoryCache.get(key);
-            if (cached != null) {
-                return cached;
-            }
+        DsDriverBindingHolder holder = findBinding(driverFamily, driverVer, key);
+        SessionFactory<?> sessionFactory = holder.getOrCreateSessionFactory(sessionFactoryName);
+        return (resourceRM, dsConfig, contextDTO) -> {
+            return createLeasedSession(holder, resourceRM, sessionFactory, dsConfig, contextDTO);
+        };
+    }
 
-            String sessionFactoryName = StringUtils.trimToNull(this.dsSessionFactory);
-            if (sessionFactoryName == null) {
-                throw new UnsupportedOperationException("no sessionFactory configured for '" + key + "'.");
+    private static Session createLeasedSession(DsDriverBindingHolder holder, DsResourceManager rm, SessionFactory factory, DataSourceConfig dsConfig,
+                                               SessionContextDTO ctx) throws Exception {
+        holder.retain();
+        boolean success = false;
+        try {
+            Session session = factory.createSession(rm, dsConfig, ctx);
+            session.addCloseListener(sessionId -> holder.release());
+            success = true;
+            return session;
+        } finally {
+            if (!success) {
+                holder.release();
             }
-
-            DriverBinding binding = findBinding(driverFamily, driverVer, key);
-            Class<?> sessionFactoryType = binding.asClassLoader().loadClass(sessionFactoryName);
-            if (!SessionFactory.class.isAssignableFrom(sessionFactoryType)) {
-                throw new IllegalStateException(sessionFactoryName + " is not a SessionFactory, driverVersion='" + key + "'.");
-            }
-
-            cached = (SessionFactory<?>) sessionFactoryType.getDeclaredConstructor().newInstance();
-            this.sessionFactoryCache.put(key, cached);
-            return cached;
         }
     }
 
-    private DriverBinding findBinding(String driverFamily, String driverVer, String key) {
+    private DsDriverBindingHolder findBinding(String driverFamily, String driverVer, String key) {
         ensureDriverCaches(driverFamily, driverVer, key);
-        DriverBinding cached = this.driverBindingCache.get(key);
+        DsDriverBindingHolder cached = this.driverBindingCache.get(key);
         if (cached != null) {
             return cached;
         }
@@ -221,8 +215,9 @@ public class DsMeta extends BaseMeta implements DsPluginInfo {
             binding.bind(this.pluginResource, this.getIncludePackages().toArray(new String[0]));
 
             this.configIncludeExclude(binding.asClassLoader());// config all bind
-            this.driverBindingCache.put(key, binding);
-            return binding;
+            DsDriverBindingHolder holder = new DsDriverBindingHolder(key, binding);
+            this.driverBindingCache.put(key, holder);
+            return holder;
         }
     }
 
@@ -233,13 +228,13 @@ public class DsMeta extends BaseMeta implements DsPluginInfo {
             return;
         }
 
-        DriverBinding cachedBinding = this.driverBindingCache.get(key);
+        DsDriverBindingHolder cachedBinding = this.driverBindingCache.get(key);
         if (cachedBinding == null || !cachedBinding.isExpired()) {
             return;
         }
 
         synchronized (this.driverBindingCache) {
-            DriverBinding bindingInLock = this.driverBindingCache.get(key);
+            DsDriverBindingHolder bindingInLock = this.driverBindingCache.get(key);
             if (bindingInLock == null || !bindingInLock.isExpired()) {
                 return;
             }
@@ -249,9 +244,19 @@ public class DsMeta extends BaseMeta implements DsPluginInfo {
     }
 
     private void clearDriverCaches(String key) {
-        this.driverBindingCache.remove(key);
-        this.driverFactoryCache.remove(key);
-        this.sessionFactoryCache.remove(key);
+        DsDriverBindingHolder holder = this.driverBindingCache.remove(key);
+        if (holder != null) {
+            holder.retire();
+        }
+    }
+
+    private DriverVersion findDriverVersion(String driverFamily, String driverVer, String key) {
+        DriverVersion driverVersion = PluginManager.driverLoader().findDriver(driverFamily, driverVer);
+        if (driverVersion == null) {
+            clearDriverCaches(key);
+            throw new UnsupportedOperationException("no driver metadata for '" + key + "'.");
+        }
+        return driverVersion;
     }
 
     private static String buildDriverKey(String driverFamily, String driverVer) {
@@ -262,4 +267,5 @@ public class DsMeta extends BaseMeta implements DsPluginInfo {
         }
         return normalizedFamily + "/" + normalizedVersion;
     }
+
 }

--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/DsMetaBinder.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/DsMetaBinder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.clougence.clouddm.platform.plugin.info;
 
 import java.util.List;

--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/FooMeta.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/FooMeta.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.clougence.clouddm.platform.plugin.info;
 
 import java.util.Collections;

--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/FooMetaBinder.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/FooMetaBinder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.clougence.clouddm.platform.plugin.info;
 
 import java.util.List;

--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/GlobalMeta.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/GlobalMeta.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.clougence.clouddm.platform.plugin.info;
 
 import java.util.*;

--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/LeasedDsFactory.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/LeasedDsFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.clougence.clouddm.platform.plugin.info;
+
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.clougence.drivers.DsFactory;
+import com.clougence.drivers.DsObject;
+
+public final class LeasedDsFactory<T> implements DsFactory<T>, AutoCloseable {
+
+    private final DsDriverBindingHolder holder;
+    private final DsFactory<T>          delegate;
+    private final AtomicBoolean         closed = new AtomicBoolean();
+
+    LeasedDsFactory(DsDriverBindingHolder holder, DsFactory<T> delegate){
+        this.holder = holder;
+        this.delegate = delegate;
+        this.holder.retain();
+    }
+
+    @Override
+    public DsObject<T> create(Properties dsConfig) throws Exception {
+        this.holder.retain();
+        boolean success = false;
+        try {
+            DsObject<T> dsObject = this.delegate.create(dsConfig);
+            dsObject.addCloseListener(this.holder::release);
+            success = true;
+            return dsObject;
+        } finally {
+            if (!success) {
+                this.holder.release();
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        if (this.closed.compareAndSet(false, true)) {
+            this.holder.release();
+        }
+    }
+}

--- a/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/LoadDef.java
+++ b/clouddm-platform/cgdm-pluginloader/src/main/java/com/clougence/clouddm/platform/plugin/info/LoadDef.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.clougence.clouddm.platform.plugin.info;
 
 import com.clougence.utils.loader.CgClassLoader;

--- a/clouddm-platform/cgdm-sidecar/src/main/java/com/clougence/clouddm/worker/component/resource/ds/AbstractDsResourceManager.java
+++ b/clouddm-platform/cgdm-sidecar/src/main/java/com/clougence/clouddm/worker/component/resource/ds/AbstractDsResourceManager.java
@@ -29,6 +29,7 @@ import com.clougence.clouddm.base.metadata.ds.DataSourceConfig;
 import com.clougence.clouddm.base.metadata.rdp.enumeration.SecurityFileType;
 import com.clougence.clouddm.platform.plugin.DsPluginInfo;
 import com.clougence.clouddm.platform.plugin.PluginManager;
+import com.clougence.clouddm.platform.plugin.info.LeasedDsFactory;
 import com.clougence.clouddm.sdk.execute.resource.DsResourceManager;
 import com.clougence.clouddm.worker.component.resource.file.FileResourceManagerImpl;
 import com.clougence.drivers.DriverLoader;
@@ -83,9 +84,7 @@ public abstract class AbstractDsResourceManager implements DsResourceManager {
             throw new UnsupportedOperationException("no plugin found for dsType '" + dsConfig.getDataSourceType() + "'.");
         }
 
-        try {
-            DsFactory<?> dsFactory = pluginInfo.createDriver(driverRef.getDriverFamily(), driverRef.getDriverVersion());
-
+        try (LeasedDsFactory<?> dsFactory = pluginInfo.createDriver(driverRef.getDriverFamily(), driverRef.getDriverVersion())) {
             Properties properties = dsConfig.asDriverProperties();
             properties.setProperty(DsConfigKeys.CLIENT_NAME.getConfigKey(), "CloudDM Client");
             DsObject<T> apply = (DsObject<T>) dsFactory.create(properties);

--- a/clouddm-utils/cg-drivers/src/main/java/com/clougence/drivers/def/VerDef.java
+++ b/clouddm-utils/cg-drivers/src/main/java/com/clougence/drivers/def/VerDef.java
@@ -105,8 +105,18 @@ public class VerDef implements DriverVersion {
 
     @Override
     public long getTimestamp() {
-        refreshTimestamp();
-        return this.timestamp;
+        long result = this.timestamp;
+        for (ResDef resource : this.resources) {
+            if (resource == null || resource.getFileDefList() == null) {
+                continue;
+            }
+
+            result = 31 * result + Boolean.hashCode(resource.isPrepared());
+            for (FileDef fileDef : resource.getFileDefList()) {
+                result = appendFileTimestamp(result, fileDef);
+            }
+        }
+        return result;
     }
 
     @Override
@@ -370,5 +380,29 @@ public class VerDef implements DriverVersion {
 
     private void refreshTimestamp() {
         this.timestamp = System.currentTimeMillis();
+    }
+
+    private static long appendFileTimestamp(long timestamp, FileDef fileDef) {
+        if (fileDef == null) {
+            return 31 * timestamp;
+        }
+
+        long result = timestamp;
+        result = 31 * result + Boolean.hashCode(fileDef.isPrepared());
+        result = 31 * result + Objects.hashCode(fileDef.getRelativePath());
+        result = 31 * result + Objects.hashCode(fileDef.getAbsolutePath());
+
+        String absolutePath = StringUtils.trimToNull(fileDef.getAbsolutePath());
+        if (absolutePath == null) {
+            return result;
+        }
+
+        File file = new File(absolutePath);
+        result = 31 * result + Boolean.hashCode(file.exists());
+        if (file.exists()) {
+            result = 31 * result + file.lastModified();
+            result = 31 * result + file.length();
+        }
+        return result;
     }
 }


### PR DESCRIPTION
1. The VerDef.getTimestamp method does not refresh the snapshot every time.
2. Instead, it decides whether to refresh the snapshot based on the content of the resource.
3. Reconstruct DsMeta by using the same DriverBinding to create DsFactory and SessionFactory, and these created objects use the reference counting scheme to uniformly cache them (to prevent the failure of secondary isolation caused by re-computation of VerDef.getTimestamp after the driver update).

---

1. The VerDef.getTimestamp method does not refresh the snapshot every time.
2. Instead, it decides whether to refresh the snapshot based on the content of the resource.
3. Reconstruct DsMeta by using the same DriverBinding to create DsFactory and SessionFactory, and these created objects use the reference counting scheme to uniformly cache them (to prevent the failure of secondary isolation caused by re-computation of VerDef.getTimestamp after the driver update).