### PR TITLE
fix: handle empty query export results to prevent division by zero Ar…

### DIFF
--- a/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/provider/NotifyRServiceProvider.java
+++ b/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/provider/NotifyRServiceProvider.java
@@ -77,7 +77,10 @@ public class NotifyRServiceProvider extends AbstractBasicProvider implements Not
         this.dmFileMapper.updateAccessTimeByUniqueId(srcFileId, message);
         this.dmFileMapper.updateAccessTimeByUniqueId(exportId, message);
 
-        int i = BigDecimal.valueOf(current).divide(BigDecimal.valueOf(to), 2, RoundingMode.HALF_UP).multiply(BigDecimal.valueOf(100)).intValue();
+        int i = 0;
+        if (to > 0) {
+            i = BigDecimal.valueOf(current).divide(BigDecimal.valueOf(to), 2, RoundingMode.HALF_UP).multiply(BigDecimal.valueOf(100)).intValue();
+        }
 
         DmExportVO exportVO = new DmExportVO();
         exportVO.setUid(userId);


### PR DESCRIPTION
### Description
This PR addresses the crash that occurs when exporting an empty query result. 

### Changes
Added a defensive guard clause in `NotifyRServiceProvider.notifyConvertProgress` to check if the total row count (`to`) is greater than 0 before performing the `BigDecimal` division, avoiding an `ArithmeticException: / by zero`.

Closes #40 