### PR TITLE
fix(initialization): remove extra input focus shadow

### DIFF
--- a/clouddm-platform/cgdm-web/src/views/initialization/index.vue
+++ b/clouddm-platform/cgdm-web/src/views/initialization/index.vue
@@ -1072,6 +1072,30 @@ export default {
   background: #f0f2f5;
 }
 
+.initialization :deep(.ant-input),
+.initialization :deep(.ant-input-affix-wrapper) {
+  color-scheme: light;
+}
+
+.initialization :deep(.ant-input-affix-wrapper .ant-input) {
+  background-color: transparent !important;
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+
+.initialization :deep(.ant-input:focus),
+.initialization :deep(.ant-input-focused),
+.initialization :deep(.ant-input-affix-wrapper-focused) {
+  box-shadow: none !important;
+}
+
+.initialization :deep(.ant-input-affix-wrapper .ant-input:focus),
+.initialization :deep(.ant-input-affix-wrapper .ant-input-focused) {
+  border-color: transparent !important;
+  box-shadow: none !important;
+  outline: none;
+}
+
 .init-error-page {
   width: 100%;
   max-width: 560px;


### PR DESCRIPTION
## Summary

- Remove the extra focus shadow shown inside initialization page inputs.
- Scope the style fix to initialization page Ant Design inputs and password affix wrappers.
- Keep the change limited to input focus rendering.

## Type

bugfix

## Related Issue

Related to #4

## Testing

- `npm run lint -- --no-fix src/views/initialization/index.vue`
- `npm run build:dm`