### PR TITLE
fix: resolve query session context bugs

### DIFF
--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/config/RootUserConfig.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/config/RootUserConfig.java
@@ -255,7 +255,7 @@ public class RootUserConfig {
     @UserConfigDef(name = "onlineResultCacheTimeoutSec", defaultValue = "300", valueRange = "0 ~ 43200", descKey = I18nUserConfigMsgKeys.SQL_RESULT_CACHE_TIMEOUT_SEC, configTagType = UserConfigTagType.QUERY_RESULT, confBelong = ConfBelong.CloudDM)
     private Integer       onlineResultCacheTimeoutSec;
     //
-    @UserConfigDef(name = "onlineMaxRecordCount", defaultValue = "10000", valueRange = "1 ~ 1000000, default 10000 records.", descKey = I18nUserConfigMsgKeys.SQL_RESULT_ONLINE_MAX_RECORD_COUNT, configTagType = UserConfigTagType.QUERY_RESULT, confBelong = ConfBelong.CloudDM)
+    @UserConfigDef(name = "onlineMaxRecordCount", defaultValue = "1000", valueRange = "1 ~ 1000000, default 10000 records.", descKey = I18nUserConfigMsgKeys.SQL_RESULT_ONLINE_MAX_RECORD_COUNT, configTagType = UserConfigTagType.QUERY_RESULT, confBelong = ConfBelong.CloudDM)
     private Integer       onlineMaxRecordCount;
     @UserConfigDef(name = "onlineMaxResultSetMegaByte", defaultValue = "60", valueRange = "4~1024 MB, default 60MB", descKey = I18nUserConfigMsgKeys.SQL_RESULT_ONLINE_MAX_RESULT_SET_MB, configTagType = UserConfigTagType.QUERY_RESULT, confBelong = ConfBelong.CloudDM)
     private Integer       onlineMaxResultSetMegaByte;

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/dsconfig/DmDsConfigService.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/dsconfig/DmDsConfigService.java
@@ -25,7 +25,6 @@ import com.clougence.clouddm.console.web.component.dsconfig.mode.DsConfig;
 import com.clougence.clouddm.console.web.component.dsconfig.mode.DsConfigKvDef;
 import com.clougence.clouddm.console.web.component.dsconfig.mode.DsLevels;
 import com.clougence.clouddm.platform.dal.model.datasource.DmDsDO;
-import com.clougence.clouddm.sdk.execute.dsconf.DsConfigField;
 
 /**
  * @author bucketli 2020/11/7 14:25
@@ -48,7 +47,7 @@ public interface DmDsConfigService {
 
     DataSourceConfig fetchDsConfigFromExists(long dsId);
 
-    DataSourceConfig fetchDsConfigFromExists(long dsId, Map<DsConfigField, String> configOverrides);
+    DataSourceConfig fetchDsConfigFromExists(long dsId, Map<String, String> configOverrides);
 
     DataSourceConfig fetchFullDsConfigFromExists(long dsId);
 

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/dsconfig/impl/DmDsConfigServiceImpl.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/dsconfig/impl/DmDsConfigServiceImpl.java
@@ -44,7 +44,6 @@ import com.clougence.clouddm.platform.dal.model.datasource.DmDsConfigKv4DmDO;
 import com.clougence.clouddm.platform.dal.model.datasource.DmDsDO;
 import com.clougence.clouddm.platform.plugin.DsPluginInfo;
 import com.clougence.clouddm.platform.plugin.PluginManager;
-import com.clougence.clouddm.sdk.execute.dsconf.DsConfigField;
 import com.clougence.clouddm.sdk.execute.dsconf.DsConfigSpi;
 import com.clougence.clouddm.sdk.execute.session.rdb.RdbSupportSpi;
 import com.clougence.clouddm.sdk.language.DsLanguageSpi;
@@ -332,7 +331,7 @@ public class DmDsConfigServiceImpl implements DmDsConfigService, UnifiedPostCons
     }
 
     @Override
-    public DataSourceConfig fetchDsConfigFromExists(long dsId, Map<DsConfigField, String> configOverrides) {
+    public DataSourceConfig fetchDsConfigFromExists(long dsId, Map<String, String> configOverrides) {
         DmDsDO dsDO = this.dsDal.dsMapper().selectById(dsId);
         List<DmDsConfigKv4DmDO> configs = this.dsDal.configKv4DmMapper().listByDsIdExcludeConfigNames(dsId, lazyConfigNames(dsDO.getDataSourceType()));
         return fetchDsConfigFromExists(dsDO, configs, configOverrides);
@@ -345,7 +344,7 @@ public class DmDsConfigServiceImpl implements DmDsConfigService, UnifiedPostCons
         return fetchDsConfigFromExists(dsDO, configs, Collections.emptyMap());
     }
 
-    private DataSourceConfig fetchDsConfigFromExists(DmDsDO dsDO, List<DmDsConfigKv4DmDO> configs, Map<DsConfigField, String> configOverrides) {
+    private DataSourceConfig fetchDsConfigFromExists(DmDsDO dsDO, List<DmDsConfigKv4DmDO> configs, Map<String, String> configOverrides) {
         Map<String, String> configMap = new HashMap<>();
         if (CollectionUtils.isNotEmpty(configs)) {
             configs.forEach(c -> {
@@ -365,15 +364,15 @@ public class DmDsConfigServiceImpl implements DmDsConfigService, UnifiedPostCons
         return dsConfig;
     }
 
-    private void fillConfigOverrides(Map<String, String> configMap, Map<DsConfigField, String> configOverrides) {
+    private void fillConfigOverrides(Map<String, String> configMap, Map<String, String> configOverrides) {
         if (configOverrides == null || configOverrides.isEmpty()) {
             return;
         }
-        configOverrides.forEach((configField, configValue) -> {
-            if (configField == null || StringUtils.isBlank(configValue)) {
+        configOverrides.forEach((configName, configValue) -> {
+            if (StringUtils.isBlank(configName) || StringUtils.isBlank(configValue)) {
                 return;
             }
-            configMap.put(configField.getConfigName(), configValue);
+            configMap.put(configName, configValue);
         });
     }
 

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/execute/impl/QueryServiceImpl.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/execute/impl/QueryServiceImpl.java
@@ -17,7 +17,9 @@ package com.clougence.clouddm.console.web.component.execute.impl;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 import org.springframework.stereotype.Service;
@@ -47,6 +49,7 @@ import com.clougence.clouddm.platform.dal.model.datasource.DmDsDO;
 import com.clougence.clouddm.platform.dal.model.execution.DmExecSessionDO;
 import com.clougence.clouddm.platform.dal.model.execution.DsSessionType;
 import com.clougence.clouddm.platform.dal.model.system.DmSysWorkerDO;
+import com.clougence.clouddm.sdk.execute.dsconf.DsConfigField;
 import com.clougence.clouddm.sdk.execute.session.QueryRequest;
 import com.clougence.clouddm.sdk.execute.session.SessionContextDTO;
 import com.clougence.clouddm.sdk.execute.session.rdb.RdbIsolation;
@@ -181,7 +184,7 @@ public class QueryServiceImpl implements QueryService {
         }
 
         // create session
-        DataSourceConfig dsConfig = this.dsConfigService.fetchDsConfigFromExists(dsDO.getId());
+        DataSourceConfig dsConfig = this.dsConfigService.fetchDsConfigFromExists(dsDO.getId(), sessionConfigOverrides(context));
         try {
             this.sessionRService.createSession(sendDTO, dsConfig, context);
             this.dsService.resetStatus(dsConfig);
@@ -190,6 +193,21 @@ public class QueryServiceImpl implements QueryService {
             throw e;
         }
         return sessionId;
+    }
+
+    private Map<String, String> sessionConfigOverrides(SessionContextDTO context) {
+        Map<String, String> configOverrides = new HashMap<>();
+        if (context == null) {
+            return configOverrides;
+        }
+
+        if (StringUtils.isNotBlank(context.getRdbCatalog())) {
+            configOverrides.put(DsConfigField.DEFAULT_DATABASE.getConfigName(), context.getRdbCatalog());
+        }
+        if (StringUtils.isNotBlank(context.getRdbSchema())) {
+            configOverrides.put(DsConfigField.DEFAULT_SCHEMA.getConfigName(), context.getRdbSchema());
+        }
+        return configOverrides;
     }
 
     @Override

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/schema/RemoteDsSchemaService.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/schema/RemoteDsSchemaService.java
@@ -89,7 +89,7 @@ public class RemoteDsSchemaService implements DsSchemaService {
         if (StringUtils.isBlank(catalogName)) {
             return this.fetchDsConfig(dataSourceDO);
         }
-        return this.dsConfigService.fetchDsConfigFromExists(dataSourceDO.getId(), Map.of(DsConfigField.DEFAULT_DATABASE, catalogName));
+        return this.dsConfigService.fetchDsConfigFromExists(dataSourceDO.getId(), Map.of(DsConfigField.DEFAULT_DATABASE.getConfigName(), catalogName));
     }
 
     @Override

--- a/backend/clouddm-platform/cgdm-plugin-loader/src/main/java/com/clougence/clouddm/platform/plugin/info/DsMeta.java
+++ b/backend/clouddm-platform/cgdm-plugin-loader/src/main/java/com/clougence/clouddm/platform/plugin/info/DsMeta.java
@@ -127,7 +127,10 @@ public class DsMeta extends BaseMeta implements DsPluginInfo {
             throw new UnsupportedOperationException("sql engine '" + engineName + "' is not bound to data source '" + this.dsType + "'. bound engines: " + engineNames);
         }
 
-        SqlEngineSpi sqlEngine = PluginManager.findSpi(SqlEngineSpi.class, engineName);
+        SqlEngineSpi sqlEngine = this.findSpi(SqlEngineSpi.class, engineName);
+        if (sqlEngine == null) {
+            sqlEngine = PluginManager.findSpi(SqlEngineSpi.class, engineName);
+        }
         if (sqlEngine == null) {
             throw new UnsupportedOperationException("sql engine '" + engineName + "' not found for data source '" + this.dsType + "'.");
         }


### PR DESCRIPTION
## Summary

Fix query-session context handling so the selected catalog/schema is written back into the generated datasource config before creating a connection. This makes queries run against the selected database/schema instead of falling back to the datasource default. Also fixes SQL engine lookup for datasource-bound engines such as SQLServer `MS T-SQL`.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Pass query-session `rdbCatalog` / `rdbSchema` into `fetchDsConfigFromExists` as datasource config overrides.
- Keep config overrides as `Map<String, String>` and derive override keys through `DsConfigField#getConfigName()`.
- Apply datasource config overrides before generating the concrete `DataSourceConfig`, so existing plugin `asDriverProperties()` logic receives the selected defaults.
- Update schema-service catalog override to use the same config-name path.
- Resolve SQL engines from the current datasource plugin meta first, with global lookup as fallback.

## Test Plan

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [x] Backend build
- [x] Manual verification

Details:

```text
./gradlew :cgdm-plugin-sdk:compileJava :cgdm-console:compileJava :cgdm-plugin-loader:compileJava
git diff --check HEAD~1..HEAD

Manual Chrome verification:
- PostgreSQL api.public: select * from "alert_config_detail" returned rows instead of ERROR: relation "alert_config_detail" does not exist.
- SQLServer add_auto_test.dbo: query executed and returned a result tab instead of sql engine 'MS T-SQL' not found.
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [x] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
