### PR TITLE
fix(cd): make release notes optional for non-latest releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,7 +53,7 @@ jobs:
             exit 1
           fi
           notes_file="docs/release-notes/v${VERSION}/index.en.md"
-          if [[ ! -f "$notes_file" ]]; then
+          if [[ "$LATEST" == "true" && ! -f "$notes_file" ]]; then
             echo "::error::release notes file does not exist: $notes_file"
             exit 1
           fi
@@ -245,9 +245,15 @@ jobs:
 
           tag="v${VERSION}"
           notes_file="docs/release-notes/v${VERSION}/index.en.md"
+          notes_args=()
+          if [[ -f "$notes_file" ]]; then
+            notes_args+=(--notes-file "$notes_file")
+          else
+            notes_args+=(--notes "Release $tag")
+          fi
           gh release create "$tag" "${assets[@]}" \
             --target "$TARGET_SHA" \
             --title "$tag" \
-            --notes-file "$notes_file" \
+            "${notes_args[@]}" \
             --prerelease="$PRERELEASE" \
             --latest="$LATEST"

--- a/package/docker/alone.Dockerfile
+++ b/package/docker/alone.Dockerfile
@@ -10,7 +10,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates curl fontconfig tzdata \
+        ca-certificates curl fontconfig tzdata vim \
         mysql-server-core-8.0 mysql-client-core-8.0 \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r mysql \

--- a/package/docker/console.Dockerfile
+++ b/package/docker/console.Dockerfile
@@ -7,7 +7,7 @@ FROM cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/eclipse-temurin:1
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl fontconfig tzdata \
+    && apt-get install -y --no-install-recommends ca-certificates curl fontconfig tzdata vim \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /docker-entrypoint-init
 

--- a/package/docker/sidecar.Dockerfile
+++ b/package/docker/sidecar.Dockerfile
@@ -7,7 +7,7 @@ FROM cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/eclipse-temurin:1
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl fontconfig tzdata \
+    && apt-get install -y --no-install-recommends ca-certificates curl fontconfig tzdata vim \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /docker-entrypoint-init
 


### PR DESCRIPTION
## Summary

Adjust the CD workflow so non-latest releases may omit the release note file, and preinstall vim in runtime images for easier troubleshooting.

## Related Issues

None

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [x] Build / tooling
- [ ] Other

## Changes

- In the CD validation stage, require `docs/release-notes/v<version>/index.en.md` only when `latest=true`; non-latest releases (such as prereleases) may omit it.
- In the Publish Release stage, fall back to `--notes \"Release v<version>\"` when the release note file does not exist, preventing `gh release create` from failing.
- Add `vim` to the apt package list in the three runtime Dockerfiles for alone, console, and sidecar.

## Test Plan

- [x] Manual verification
- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [ ] Backend build

Details:


- Manually triggered CD with `latest=false` and a missing release note; verified validation passed and a GitHub Release was created successfully
- Manually triggered CD with `latest=true` and a missing release note; verified the validation stage reported an error
- Pulled the new image and verified that vim is available in the container

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [x] Documentation was updated when behavior or usage changed.
- [x] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.