### PR TITLE
feat(github): add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,0 +1,105 @@
+name: Issue report
+description: Report a bug, suggest a feature, or propose a documentation improvement.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve CloudDM.
+
+        Use a clear title prefixed with `[Bug]`, `[Feature]`, or `[Docs]`. For security vulnerabilities, do not include secrets or other sensitive information in a public issue.
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue type
+      description: Select the category that best describes this issue.
+      options:
+        - Bug report
+        - Feature request
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the issue or request.
+      placeholder: What happened, or what would you like CloudDM to support?
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: Explain the impact, affected workflow, or problem this change would solve.
+      placeholder: Who is affected, and why is this important?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe the expected result or desired outcome.
+      placeholder: What should happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: For bugs, provide the smallest reliable set of reproduction steps. Write "Not applicable" for other issue types.
+      placeholder: |
+        1. Configure ...
+        2. Open ...
+        3. Run ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: For bugs, describe what happened instead, including any visible error messages.
+      placeholder: What did CloudDM do?
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: For bugs, include every relevant version and deployment detail.
+      placeholder: |
+        - CloudDM version:
+        - Deployment mode: Alone / Console + Sidecar
+        - Operating system:
+        - Browser and version:
+        - JDK version:
+        - Database type and version:
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant logs or attach screenshots. Remove passwords, tokens, connection strings, and other sensitive data.
+      placeholder: Add logs, screenshots, or a minimal reproduction here.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add related issues, possible solutions, or comparable implementations.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I removed passwords, tokens, connection strings, and other sensitive data.
+          required: true


### PR DESCRIPTION
## Summary

Add a structured GitHub Issue Form for CloudDM contributors.

The repository previously had contribution guidance for bug reports, feature requests, and documentation feedback, but no Issue template to collect that information consistently.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Add a single Issue Form covering bugs, feature requests, documentation feedback, and other reports.
- Collect the issue summary, problem or use case, expected behavior, reproduction steps, environment details, logs, screenshots, and additional context.
- Require contributors to confirm that they searched for duplicates and removed sensitive information.

## User Impact

Contributors receive a guided form when opening an Issue, giving maintainers more consistent and actionable reports.

## Test Plan

- [x] Parsed the Issue Form as YAML.
- [x] Verified all form input IDs are unique.
- [x] Ran `git diff --check`.

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [x] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
