### PR TITLE
feat(mongodb): support MongoDB 4.0 compatibility

### DIFF
--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/build.gradle
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compileOnly project(':cgdm-share-libs')
 
     // driver libs (compileOnly)
-    compileOnly 'org.mongodb:mongodb-driver-sync:5.6.5'
+    compileOnly 'org.mongodb:mongodb-driver-sync:5.9.0'
 }
 
 description = 'ds-mongodb'

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/dsconf/MongoConfig.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/dsconf/MongoConfig.java
@@ -23,6 +23,7 @@ import com.clougence.clouddm.base.metadata.ds.DataSourceType;
 import com.clougence.clouddm.base.metadata.ds.DsConfigGroup;
 import com.clougence.clouddm.ds.mongodb.i18n.MongoConfigI18nKeys;
 import com.clougence.clouddm.sdk.execute.dsconf.Serialization;
+import com.clougence.drivers.DriverSpecUtils;
 import com.clougence.drivers.DsConfigKeys;
 import com.clougence.utils.StringUtils;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -59,6 +60,7 @@ public class MongoConfig extends DataSourceConfig {
     public Properties asDriverProperties() {
         Properties properties = new Properties();
         properties.setProperty(DsConfigKeys.ID.getConfigKey(), safeStr(this.getInstanceId()));
+        properties.setProperty(DsConfigKeys.DRIVER_VERSION.getConfigKey(), safeStr(DriverSpecUtils.resolveDriverVersion(this.getDriverVersion())));
         properties.setProperty(DsConfigKeys.HOST.getConfigKey(), safeStr(this.getHost()));
         properties.setProperty(DsConfigKeys.USER.getConfigKey(), safeStr(this.getUserName()));
         properties.setProperty(DsConfigKeys.PASSWORD.getConfigKey(), safeStr(this.getPassword()));

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/dsfactory/AbstractMongoJdbcDsFactory.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/dsfactory/AbstractMongoJdbcDsFactory.java
@@ -26,20 +26,22 @@ import com.clougence.clouddm.ds.mongodb.execute.jdbc.MongoKeys;
 import com.clougence.drivers.DsConfigKeys;
 import com.clougence.drivers.DsFactory;
 import com.clougence.drivers.DsObject;
+import com.clougence.drivers.adapter.AdapterManager;
 import com.clougence.drivers.adapter.JdbcDriver;
 import com.clougence.utils.StringUtils;
 import com.mongodb.ServerAddress;
 
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * https://dev.mysql.com/doc/refman/8.0/en/information-schema.html
- * @author mode 2021/01/08 20:29
- */
 @Slf4j
-public class MongoJdbcDsFactory implements DsFactory<Connection> {
+abstract class AbstractMongoJdbcDsFactory implements DsFactory<Connection> {
 
-    private final MongoConnectionFactory connectionFactory = new MongoConnectionFactory();
+    private final String adapterName;
+
+    protected AbstractMongoJdbcDsFactory(String adapterName){
+        this.adapterName = adapterName;
+        AdapterManager.register(adapterName, new MongoConnectionFactory(adapterName));
+    }
 
     @Override
     public DsObject<Connection> create(Properties dsConfig) throws SQLException {
@@ -51,14 +53,10 @@ public class MongoJdbcDsFactory implements DsFactory<Connection> {
 
         String id = dsConfig.getProperty(DsConfigKeys.ID.getConfigKey());
         String driverVersion = dsConfig.getProperty(DsConfigKeys.DRIVER_VERSION.getConfigKey());
-        String username = dsConfig.getProperty(DsConfigKeys.USER.getConfigKey());
-        String password = dsConfig.getProperty(DsConfigKeys.PASSWORD.getConfigKey());
-        String loginTimeoutMs = dsConfig.getProperty(DsConfigKeys.LOGIN_TIMEOUT_MS.getConfigKey());
         String connTimeoutMs = dsConfig.getProperty(DsConfigKeys.CONNECT_TIMEOUT_MS.getConfigKey());
         String soTimeoutSec = dsConfig.getProperty(DsConfigKeys.SO_TIMEOUT_SEC.getConfigKey());
         String clientName = dsConfig.getProperty(DsConfigKeys.CLIENT_NAME.getConfigKey());
         String defaultSchema = dsConfig.getProperty(DsConfigKeys.DEFAULT_SCHEMA.getConfigKey());
-        String clientEncoding = dsConfig.getProperty(DsConfigKeys.CLIENT_ENCODING.getConfigKey());
         String tcpKeepAlive = dsConfig.getProperty(DsConfigKeys.TCP_KEEP_ALIVE.getConfigKey());
         if (StringUtils.isNotBlank(driverVersion)) {
             props.put(MongoKeys.DRIVER_VERSION, driverVersion);
@@ -85,28 +83,32 @@ public class MongoJdbcDsFactory implements DsFactory<Connection> {
         String jdbcUrl = buildJdbcUrl(dsConfig);
 
         try {
-            Connection connection = new JdbcDriver().connect(jdbcUrl, props, this.connectionFactory);
+            Connection connection = new JdbcDriver().connect(jdbcUrl, props);
             return new DsObject<>(dsConfig, connection, this);
         } catch (Exception e) {
-            log.error("create EsClient instanceID(MongoDB)=" + id + " ,hosts= " + dsConfig.getProperty(DsConfigKeys.HOST.getConfigKey()) + ", error:" + e.getMessage());
+            log.error("create MongoDB connection failed, instanceId=" + id + ", hosts=" + dsConfig.getProperty(DsConfigKeys.HOST.getConfigKey()), e);
             throw e;
         }
     }
 
     protected String buildJdbcUrl(Properties dsConfig) {
-        String jdbcURL = dsConfig.getProperty(DsConfigKeys.CUSTOM_URL.getConfigKey());
-        if (StringUtils.isNotBlank(jdbcURL)) {
-            return jdbcURL;
+        String jdbcUrl = dsConfig.getProperty(DsConfigKeys.CUSTOM_URL.getConfigKey());
+        if (StringUtils.isNotBlank(jdbcUrl)) {
+            if (jdbcUrl.startsWith(MongoKeys.LEGACY_START_URL)) {
+                return JdbcDriver.START_URL + this.adapterName + jdbcUrl.substring(MongoKeys.LEGACY_START_URL.length() - 1);
+            }
+            return jdbcUrl;
         }
         String username = dsConfig.getProperty(DsConfigKeys.USER.getConfigKey());
         String password = dsConfig.getProperty(DsConfigKeys.PASSWORD.getConfigKey());
         String host = dsConfig.getProperty(DsConfigKeys.HOST.getConfigKey());
         String hosts = buildHosts(parseServerAddress(host));
+        String startUrl = JdbcDriver.START_URL + this.adapterName + "://";
 
         if (StringUtils.isBlank(username)) {
-            return JdbcDriver.START_URL + "mongodb://" + hosts;
+            return startUrl + hosts;
         }
-        return String.format(JdbcDriver.START_URL + "mongodb://%s:%s@%s", username, password, hosts);
+        return String.format(startUrl + "%s:%s@%s", username, password, hosts);
     }
 
     private List<ServerAddress> parseServerAddress(String mongoAddress) {

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/dsfactory/Mongo4JdbcDsFactory.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/dsfactory/Mongo4JdbcDsFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.clougence.clouddm.ds.mongodb.execute.dsfactory;
+
+import com.clougence.clouddm.ds.mongodb.execute.jdbc.MongoKeys;
+
+public class Mongo4JdbcDsFactory extends AbstractMongoJdbcDsFactory {
+
+    public Mongo4JdbcDsFactory(){
+        super(MongoKeys.MONGO4_ADAPTER_NAME);
+    }
+}

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/dsfactory/Mongo5JdbcDsFactory.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/dsfactory/Mongo5JdbcDsFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.clougence.clouddm.ds.mongodb.execute.dsfactory;
+
+import com.clougence.clouddm.ds.mongodb.execute.jdbc.MongoKeys;
+
+public class Mongo5JdbcDsFactory extends AbstractMongoJdbcDsFactory {
+
+    public Mongo5JdbcDsFactory(){
+        super(MongoKeys.MONGO5_ADAPTER_NAME);
+    }
+}

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/dsfactory/MongoJdbcDsFactory.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/dsfactory/MongoJdbcDsFactory.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import com.clougence.clouddm.ds.mongodb.execute.jdbc.MongoConnectionFactory;
 import com.clougence.clouddm.ds.mongodb.execute.jdbc.MongoKeys;
 import com.clougence.drivers.DsConfigKeys;
 import com.clougence.drivers.DsFactory;
@@ -38,6 +39,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MongoJdbcDsFactory implements DsFactory<Connection> {
 
+    private final MongoConnectionFactory connectionFactory = new MongoConnectionFactory();
+
     @Override
     public DsObject<Connection> create(Properties dsConfig) throws SQLException {
         Properties props = new Properties();
@@ -47,6 +50,7 @@ public class MongoJdbcDsFactory implements DsFactory<Connection> {
         }
 
         String id = dsConfig.getProperty(DsConfigKeys.ID.getConfigKey());
+        String driverVersion = dsConfig.getProperty(DsConfigKeys.DRIVER_VERSION.getConfigKey());
         String username = dsConfig.getProperty(DsConfigKeys.USER.getConfigKey());
         String password = dsConfig.getProperty(DsConfigKeys.PASSWORD.getConfigKey());
         String loginTimeoutMs = dsConfig.getProperty(DsConfigKeys.LOGIN_TIMEOUT_MS.getConfigKey());
@@ -56,6 +60,9 @@ public class MongoJdbcDsFactory implements DsFactory<Connection> {
         String defaultSchema = dsConfig.getProperty(DsConfigKeys.DEFAULT_SCHEMA.getConfigKey());
         String clientEncoding = dsConfig.getProperty(DsConfigKeys.CLIENT_ENCODING.getConfigKey());
         String tcpKeepAlive = dsConfig.getProperty(DsConfigKeys.TCP_KEEP_ALIVE.getConfigKey());
+        if (StringUtils.isNotBlank(driverVersion)) {
+            props.put(MongoKeys.DRIVER_VERSION, driverVersion);
+        }
         if (StringUtils.isNotBlank(clientName)) {
             // client info cannot contain spaces, newlines or special characters.
             clientName = clientName.replace(" ", "-");
@@ -78,7 +85,7 @@ public class MongoJdbcDsFactory implements DsFactory<Connection> {
         String jdbcUrl = buildJdbcUrl(dsConfig);
 
         try {
-            Connection connection = new JdbcDriver().connect(jdbcUrl, props);
+            Connection connection = new JdbcDriver().connect(jdbcUrl, props, this.connectionFactory);
             return new DsObject<>(dsConfig, connection, this);
         } catch (Exception e) {
             log.error("create EsClient instanceID(MongoDB)=" + id + " ,hosts= " + dsConfig.getProperty(DsConfigKeys.HOST.getConfigKey()) + ", error:" + e.getMessage());
@@ -96,6 +103,9 @@ public class MongoJdbcDsFactory implements DsFactory<Connection> {
         String host = dsConfig.getProperty(DsConfigKeys.HOST.getConfigKey());
         String hosts = buildHosts(parseServerAddress(host));
 
+        if (StringUtils.isBlank(username)) {
+            return JdbcDriver.START_URL + "mongodb://" + hosts;
+        }
         return String.format(JdbcDriver.START_URL + "mongodb://%s:%s@%s", username, password, hosts);
     }
 

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/ClientCallForCollection.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/ClientCallForCollection.java
@@ -36,34 +36,37 @@ import com.mongodb.client.model.RenameCollectionOptions;
 
 public class ClientCallForCollection extends MongoUtils {
 
-    public static CgFuture<?> findFunc(CgFuture<Object> sync, MongoClient client, ClientSession session, CollectionFunc func, AdapterRequest request, AdapterReceive receive,
-                                       String database) throws SQLException, IOException {
+    public static CgFuture<?> findFunc(CgFuture<Object> sync, MongoClient client, CollectionFunc func, AdapterRequest request, AdapterReceive receive, String database,
+                                       MongoSessionProvider sessionProvider) throws SQLException, IOException {
         MongoDatabase database1 = client.getDatabase(database);
-        Document result = database1.runCommand(session, Document.parse(func.toBson()));
-
-        MongoResultBuffer buffer = new MongoResultBuffer();
-        Iterator<Document> iterator = new CursorResult(result, database1, session, func.getCollectionName()).iterator();
-        return handleResult(sync, request, receive, buffer, iterator);
+        try (ClientSession session = sessionProvider.startSession()) {
+            Document result = runCommand(database1, session, Document.parse(func.toBson()));
+            MongoResultBuffer buffer = new MongoResultBuffer();
+            try (CursorResult cursorResult = new CursorResult(result, database1, session)) {
+                Iterator<Document> iterator = cursorResult.iterator();
+                return handleResult(sync, request, receive, buffer, iterator);
+            }
+        }
     }
 
-    public static CgFuture<?> renameCollectionFunc(CgFuture<Object> sync, MongoClient client, ClientSession session, RenameCollectionFunc func, AdapterRequest request,
-                                                   AdapterReceive receive, String database) throws SQLException {
+    public static CgFuture<?> renameCollectionFunc(CgFuture<Object> sync, MongoClient client, RenameCollectionFunc func, AdapterRequest request, AdapterReceive receive,
+                                                   String database) throws SQLException {
         RenameCollectionOptions renameCollectionOptions;
         if (func.getDropTarget() != null) {
             renameCollectionOptions = new RenameCollectionOptions().dropTarget(func.getDropTarget());
         } else {
             renameCollectionOptions = new RenameCollectionOptions();
         }
-        client.getDatabase(database).getCollection(func.getCollectionName()).renameCollection(session, new MongoNamespace(database, func.getTo()), renameCollectionOptions);
+        client.getDatabase(database).getCollection(func.getCollectionName()).renameCollection(new MongoNamespace(database, func.getTo()), renameCollectionOptions);
 
         receive.responseResult(request, MongoUtils.singleResult(request, MongoUtils.RESULT_COLUMN, "ok"));
         return completed(sync);
     }
 
-    public static CgFuture<?> dataSizeFunc(CgFuture<Object> sync, MongoClient client, ClientSession session, DataSizeFunc func, AdapterRequest request, AdapterReceive receive,
+    public static CgFuture<?> dataSizeFunc(CgFuture<Object> sync, MongoClient client, DataSizeFunc func, AdapterRequest request, AdapterReceive receive,
                                            String database) throws SQLException, IOException {
         String command = func.toBson(database);
-        Document result = client.getDatabase(database).runCommand(session, Document.parse(command));
+        Document result = client.getDatabase(database).runCommand(Document.parse(command));
 
         return handleResult(sync, request, receive, new MongoResultBuffer(), Collections.singletonList(result).iterator());
     }

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/ClientCallForCommand.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/ClientCallForCommand.java
@@ -24,14 +24,13 @@ import org.bson.Document;
 import com.clougence.drivers.adapter.AdapterReceive;
 import com.clougence.drivers.adapter.AdapterRequest;
 import com.clougence.utils.future.CgFuture;
-import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoClient;
 
 public class ClientCallForCommand extends MongoUtils {
 
-    public static CgFuture<?> runCommand(CgFuture<Object> sync, MongoClient client, ClientSession session, String command, AdapterRequest request, AdapterReceive receive,
+    public static CgFuture<?> runCommand(CgFuture<Object> sync, MongoClient client, String command, AdapterRequest request, AdapterReceive receive,
                                          String database) throws SQLException, IOException {
-        Document result = client.getDatabase(database).runCommand(session, Document.parse(command));
+        Document result = client.getDatabase(database).runCommand(Document.parse(command));
 
         return handleResult(sync, request, receive, new MongoResultBuffer(), Collections.singletonList(result).iterator());
     }

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/ClientCallForDatabase.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/ClientCallForDatabase.java
@@ -29,12 +29,14 @@ import com.mongodb.client.MongoDatabase;
 
 public class ClientCallForDatabase extends MongoUtils {
 
-    public static CgFuture<?> listCollections(CgFuture<Object> sync, MongoClient client, ClientSession session, String command, AdapterRequest request, AdapterReceive receive,
-                                              String database) throws SQLException, IOException {
+    public static CgFuture<?> listCollections(CgFuture<Object> sync, MongoClient client, String command, AdapterRequest request, AdapterReceive receive, String database,
+                                              MongoSessionProvider sessionProvider) throws SQLException, IOException {
         MongoDatabase database1 = client.getDatabase(database);
-        ClientSession clientSession = client.startSession();
-        Document result = database1.runCommand(session, Document.parse(command));
-
-        return handleResult(sync, request, receive, new MongoResultBuffer(), new CursorResult(result, database1, clientSession).iterator());
+        try (ClientSession session = sessionProvider.startSession()) {
+            Document result = runCommand(database1, session, Document.parse(command));
+            try (CursorResult cursorResult = new CursorResult(result, database1, session)) {
+                return handleResult(sync, request, receive, new MongoResultBuffer(), cursorResult.iterator());
+            }
+        }
     }
 }

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/ClientCallForShow.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/ClientCallForShow.java
@@ -23,24 +23,44 @@ import org.bson.Document;
 import com.clougence.drivers.adapter.AdapterReceive;
 import com.clougence.drivers.adapter.AdapterRequest;
 import com.clougence.utils.future.CgFuture;
-import com.mongodb.client.ClientSession;
 import com.mongodb.client.ListCollectionsIterable;
 import com.mongodb.client.ListDatabasesIterable;
 import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCursor;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class ClientCallForShow extends MongoUtils {
 
-    public static CgFuture<?> showDatabasesFunc(CgFuture<Object> sync, MongoClient client, ClientSession session, AdapterRequest request,
-                                                AdapterReceive receive) throws SQLException, IOException {
-        ListDatabasesIterable<Document> documents = client.listDatabases(session);
+    public static CgFuture<?> showDatabasesFunc(CgFuture<Object> sync, MongoClient client, AdapterRequest request, AdapterReceive receive) throws SQLException, IOException {
+        ListDatabasesIterable<Document> documents = client.listDatabases();
 
-        return handleResult(sync, request, receive, new MongoResultBuffer(), documents.iterator());
+        MongoCursor<Document> cursor = documents.iterator();
+        try {
+            return handleResult(sync, request, receive, new MongoResultBuffer(), cursor);
+        } finally {
+            try {
+                cursor.close();
+            } catch (RuntimeException e) {
+                log.error("close MongoDB database cursor failed, but ignore", e);
+            }
+        }
     }
 
-    public static CgFuture<?> showCollectionsFunc(CgFuture<Object> sync, MongoClient client, ClientSession session, AdapterRequest request, AdapterReceive receive,
-                                                  String database) throws SQLException, IOException {
-        ListCollectionsIterable<Document> documents = client.getDatabase(database).listCollections(session);
+    public static CgFuture<?> showCollectionsFunc(CgFuture<Object> sync, MongoClient client, AdapterRequest request, AdapterReceive receive, String database) throws SQLException,
+                                                                                                                                                              IOException {
+        ListCollectionsIterable<Document> documents = client.getDatabase(database).listCollections();
 
-        return handleResult(sync, request, receive, new MongoResultBuffer(), documents.iterator());
+        MongoCursor<Document> cursor = documents.iterator();
+        try {
+            return handleResult(sync, request, receive, new MongoResultBuffer(), cursor);
+        } finally {
+            try {
+                cursor.close();
+            } catch (RuntimeException e) {
+                log.error("close MongoDB collection cursor failed, but ignore, database=" + database, e);
+            }
+        }
     }
 }

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/CursorResult.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/CursorResult.java
@@ -15,17 +15,19 @@
  */
 package com.clougence.clouddm.ds.mongodb.execute.jdbc;
 
-import java.util.Iterator;
-import java.util.List;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.bson.Document;
 
+import com.mongodb.MongoNamespace;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoDatabase;
 
-public class CursorResult implements Iterable<Document> {
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CursorResult implements Iterable<Document>, AutoCloseable {
 
     private final Queue<Document> documents = new LinkedBlockingQueue<>();
     private Long                  id;
@@ -33,17 +35,15 @@ public class CursorResult implements Iterable<Document> {
     private final MongoDatabase   database;
     private final ClientSession   clientSession;
     private final String          collectionName;
+    private boolean               closed;
 
-    public CursorResult(Document document, MongoDatabase database, ClientSession clientSession){
-        this(document, database, clientSession, null);
-    }
-
-    public CursorResult(Document firstResult, MongoDatabase database, ClientSession clientSession, String collectionName){
-        this.collectionName = collectionName;
-        this.clientSession = clientSession;
+    public CursorResult(Document firstResult, MongoDatabase database, ClientSession clientSession){
         this.database = database;
+        this.clientSession = clientSession;
+        this.closed = false;
 
         Document cursor = (Document) firstResult.get("cursor");
+        this.collectionName = new MongoNamespace(cursor.getString("ns")).getCollectionName();
         this.id = cursor.getLong("id");
         List<Document> list = cursor.getList("firstBatch", Document.class);
         this.documents.addAll(list);
@@ -54,27 +54,62 @@ public class CursorResult implements Iterable<Document> {
         return new FindResultIterator();
     }
 
+    @Override
+    public void close() {
+        if (this.closed) {
+            return;
+        }
+        this.closed = true;
+
+        Long cursorId = this.id;
+        this.id = 0L;
+        this.documents.clear();
+        if (cursorId == null || cursorId == 0) {
+            return;
+        }
+
+        Document command = new Document("killCursors", this.collectionName).append("cursors", Collections.singletonList(cursorId));
+        try {
+            MongoUtils.runCommand(this.database, this.clientSession, command);
+        } catch (RuntimeException e) {
+            String msg = "kill MongoDB cursor failed, but ignore, database=" + this.database.getName() + ", collection=" + this.collectionName + ", cursorId=" + cursorId;
+            log.error(msg, e);
+        }
+    }
+
     public class FindResultIterator implements Iterator<Document> {
 
         @Override
         public boolean hasNext() {
-            if (documents.isEmpty()) {
-                if (id == null || id == 0) {
-                    return false;
-                } else {
-                    Document parse = Document.parse("{getMore:" + id + ",\"collection\":\"" + collectionName + "\",batchSize:100}");
-                    Document document1 = database.runCommand(clientSession, parse);
-                    Document cursor = (Document) document1.get("cursor");
-                    id = cursor.getLong("id");
-                    documents.addAll(cursor.getList("nextBatch", Document.class));
-                }
+            if (closed) {
+                return false;
             }
-            return true;
+            while (documents.isEmpty()) {
+                if (id == null || id == 0) {
+                    break;
+                }
+
+                Document command = new Document("getMore", id).append("collection", collectionName).append("batchSize", 100);
+                Document result;
+                if (clientSession == null) {
+                    result = database.runCommand(command);
+                } else {
+                    result = database.runCommand(clientSession, command);
+                }
+
+                Document cursor = (Document) result.get("cursor");
+                id = cursor.getLong("id");
+                documents.addAll(cursor.getList("nextBatch", Document.class));
+            }
+            return !documents.isEmpty();
         }
 
         @Override
         public Document next() {
-            return documents.poll();
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return documents.remove();
         }
     }
 }

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoConnection.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoConnection.java
@@ -34,21 +34,20 @@ import com.clougence.sql.mongodb.parser.ast.commands.client.UserFunc;
 import com.clougence.utils.ExceptionUtils;
 import com.clougence.utils.future.CgFuture;
 import com.clougence.utils.future.CgFutureObj;
-import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoClient;
 
 public class MongoConnection extends AdapterConnection {
 
-    private final Connection    owner;
-    private final MongoClient   client;
-    private final ClientSession session;
-    private String              database;
+    private final Connection           owner;
+    private final MongoClient          client;
+    private final MongoSessionProvider sessionProvider;
+    private String                     database;
 
     MongoConnection(Connection owner, MongoClient client, String jdbcUrl, Properties properties, String database){
         super(jdbcUrl, properties.getProperty(MongoKeys.USERNAME));
         this.owner = owner;
         this.client = client;
-        this.session = client.startSession();
+        this.sessionProvider = new MongoSessionProvider(client, properties.getProperty(MongoKeys.DRIVER_VERSION));
         this.database = database;
     }
 
@@ -109,15 +108,14 @@ public class MongoConnection extends AdapterConnection {
 
         for (Statement command : cmdSet) {
             CgFuture<Object> sync = new CgFutureObj<>();
-            execCommand(sync, this.client, this.session, (AbstractMongoFunc) command, request, receive);
+            execCommand(sync, this.client, (AbstractMongoFunc) command, request, receive);
             sync.await();
         }
 
         receive.responseFinish(request);
     }
 
-    private void execCommand(CgFuture<Object> sync, MongoClient jedisCmd, ClientSession session, AbstractMongoFunc func, AdapterRequest request,
-                             AdapterReceive receive) throws SQLException {
+    private void execCommand(CgFuture<Object> sync, MongoClient jedisCmd, AbstractMongoFunc func, AdapterRequest request, AdapterReceive receive) throws SQLException {
         switch (func.getFuncType()) {
             case USE: {
                 this.database = ((UserFunc) func).getDatabase();
@@ -127,7 +125,7 @@ public class MongoConnection extends AdapterConnection {
             }
             default: {
                 try {
-                    MongoDistributeCall.execFunc(sync, jedisCmd, session, func, request, receive, this.database);
+                    MongoDistributeCall.execFunc(sync, jedisCmd, func, request, receive, this.database, this.sessionProvider);
                 } catch (IOException e) {
                     throw new SQLException(e);
                 }
@@ -142,8 +140,6 @@ public class MongoConnection extends AdapterConnection {
 
     @Override
     protected void doClose() throws IOException {
-        this.cancelRequest();
-        this.session.close();
         this.client.close();
     }
 }

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoConnectionFactory.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoConnectionFactory.java
@@ -31,8 +31,14 @@ import com.mongodb.client.MongoClients;
 
 public class MongoConnectionFactory implements AdapterFactory {
 
+    private final String adapterName;
+
+    public MongoConnectionFactory(String adapterName){
+        this.adapterName = adapterName;
+    }
+
     @Override
-    public String getAdapterName() { return "mongodb"; }
+    public String getAdapterName() { return this.adapterName; }
 
     @Override
     public String[] getPropertyNames() {
@@ -60,7 +66,7 @@ public class MongoConnectionFactory implements AdapterFactory {
         }
 
         int i = jdbcUrl.indexOf(JdbcDriver.START_URL) + JdbcDriver.START_URL.length();
-        String mongoUrl = jdbcUrl.substring(i);
+        String mongoUrl = "mongodb" + jdbcUrl.substring(i + this.adapterName.length());
         int queryIndex = mongoUrl.indexOf('?');
         int schemeEnd = mongoUrl.indexOf("://") + 3;
         int authorityEnd = queryIndex < 0 ? mongoUrl.length() : queryIndex;

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoConnectionFactory.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoConnectionFactory.java
@@ -18,7 +18,6 @@ package com.clougence.clouddm.ds.mongodb.execute.jdbc;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 import com.clougence.drivers.adapter.AdapterFactory;
 import com.clougence.drivers.adapter.AdapterTypeSupport;
@@ -37,9 +36,9 @@ public class MongoConnectionFactory implements AdapterFactory {
 
     @Override
     public String[] getPropertyNames() {
-        return new String[] { MongoKeys.SERVER, MongoKeys.ADAPTER_NAME, MongoKeys.INTERCEPTOR, MongoKeys.TIME_ZONE, MongoKeys.CONN_TIMEOUT, MongoKeys.SO_TIMEOUT,
-                              MongoKeys.USERNAME, MongoKeys.PASSWORD, MongoKeys.DATABASE, MongoKeys.CLIENT_NAME, MongoKeys.MAX_TOTAL, MongoKeys.MAX_IDLE, MongoKeys.MIN_IDLE,
-                              MongoKeys.TEST_WHILE_IDLE };
+        return new String[] { MongoKeys.SERVER, MongoKeys.ADAPTER_NAME, MongoKeys.DRIVER_VERSION, MongoKeys.INTERCEPTOR, MongoKeys.TIME_ZONE, MongoKeys.CONN_TIMEOUT,
+                              MongoKeys.SO_TIMEOUT, MongoKeys.USERNAME, MongoKeys.PASSWORD, MongoKeys.DATABASE, MongoKeys.CLIENT_NAME, MongoKeys.MAX_TOTAL, MongoKeys.MAX_IDLE,
+                              MongoKeys.MIN_IDLE, MongoKeys.TEST_WHILE_IDLE };
     }
 
     @Override
@@ -61,13 +60,22 @@ public class MongoConnectionFactory implements AdapterFactory {
         }
 
         int i = jdbcUrl.indexOf(JdbcDriver.START_URL) + JdbcDriver.START_URL.length();
-        MongoClientSettings.Builder settingsBuilder = MongoClientSettings.builder()
-            .applicationName(clientName)
-            .applyConnectionString(new ConnectionString(jdbcUrl.substring(i)))
-            .applyToSocketSettings(b -> {
-                b.connectTimeout(connTimeoutMs, TimeUnit.MILLISECONDS);
-                b.readTimeout(soTimeoutMs, TimeUnit.MILLISECONDS);
-            });
+        String mongoUrl = jdbcUrl.substring(i);
+        int queryIndex = mongoUrl.indexOf('?');
+        int schemeEnd = mongoUrl.indexOf("://") + 3;
+        int authorityEnd = queryIndex < 0 ? mongoUrl.length() : queryIndex;
+        int pathIndex = mongoUrl.indexOf('/', schemeEnd);
+        if (pathIndex < 0 || pathIndex >= authorityEnd) {
+            mongoUrl = mongoUrl.substring(0, authorityEnd) + "/" + mongoUrl.substring(authorityEnd);
+        }
+
+        String optionSeparator = "?";
+        if (mongoUrl.contains("?")) {
+            optionSeparator = "&";
+        }
+        mongoUrl = mongoUrl + optionSeparator + "connectTimeoutMS=" + connTimeoutMs + "&socketTimeoutMS=" + soTimeoutMs;
+
+        MongoClientSettings.Builder settingsBuilder = MongoClientSettings.builder().applicationName(clientName).applyConnectionString(new ConnectionString(mongoUrl));
 
         MongoClient client = MongoClients.create(settingsBuilder.build());
         return new MongoConnection(owner, client, jdbcUrl, props, props.getProperty(MongoKeys.DATABASE));

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoDistributeCall.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoDistributeCall.java
@@ -25,7 +25,6 @@ import com.clougence.sql.mongodb.parser.ast.commands.collection.CollectionFunc;
 import com.clougence.sql.mongodb.parser.ast.commands.collection.DataSizeFunc;
 import com.clougence.sql.mongodb.parser.ast.commands.collection.RenameCollectionFunc;
 import com.clougence.utils.future.CgFuture;
-import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoClient;
 
 import lombok.extern.slf4j.Slf4j;
@@ -33,24 +32,24 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 class MongoDistributeCall {
 
-    public static CgFuture<?> execFunc(CgFuture<Object> sync, MongoClient client, ClientSession session, AbstractMongoFunc func, AdapterRequest request, AdapterReceive receive,
-                                       String database) throws SQLException, IOException {
+    public static CgFuture<?> execFunc(CgFuture<Object> sync, MongoClient client, AbstractMongoFunc func, AdapterRequest request, AdapterReceive receive, String database,
+                                       MongoSessionProvider sessionProvider) throws SQLException, IOException {
         switch (func.getFuncType().getCommandType()) {
             /* ------------------------------------------------------------------------------------------------ String Commands */
             case SHOW_DATABASES:
-                return ClientCallForShow.showDatabasesFunc(sync, client, session, request, receive);
+                return ClientCallForShow.showDatabasesFunc(sync, client, request, receive);
             case SHOW_COLLECTIONS:
-                return ClientCallForShow.showCollectionsFunc(sync, client, session, request, receive, database);
+                return ClientCallForShow.showCollectionsFunc(sync, client, request, receive, database);
             case DATA_SIZE:
-                return ClientCallForCollection.dataSizeFunc(sync, client, session, (DataSizeFunc) func, request, receive, database);
+                return ClientCallForCollection.dataSizeFunc(sync, client, (DataSizeFunc) func, request, receive, database);
             case FIND:
             case AGGREGATE:
             case LIST_INDEXES:
-                return ClientCallForCollection.findFunc(sync, client, session, (CollectionFunc) func, request, receive, database);
+                return ClientCallForCollection.findFunc(sync, client, (CollectionFunc) func, request, receive, database, sessionProvider);
             case LIST_COLLECTIONS:
-                return ClientCallForDatabase.listCollections(sync, client, session, func.toBson(), request, receive, database);
+                return ClientCallForDatabase.listCollections(sync, client, func.toBson(), request, receive, database, sessionProvider);
             case RENAME_COLLECTION:
-                return ClientCallForCollection.renameCollectionFunc(sync, client, session, (RenameCollectionFunc) func, request, receive, database);
+                return ClientCallForCollection.renameCollectionFunc(sync, client, (RenameCollectionFunc) func, request, receive, database);
             case INSERT:
             case DELETE:
             case UPDATE:
@@ -71,7 +70,7 @@ class MongoDistributeCall {
             case HOST_INFO:
             case DROP_DATABASE:
             case EXPLAIN:
-                return ClientCallForCommand.runCommand(sync, client, session, func.toBson(), request, receive, database);
+                return ClientCallForCommand.runCommand(sync, client, func.toBson(), request, receive, database);
             // adminCommand
             case ADMIN_COMMAND:
             case BUILD_INFO:
@@ -80,7 +79,7 @@ class MongoDistributeCall {
             case FSYNC_UNLOCK:
             case GET_PARAMETER:
             case KILL_OP:
-                return ClientCallForCommand.runCommand(sync, client, session, func.toBson(), request, receive, "admin");
+                return ClientCallForCommand.runCommand(sync, client, func.toBson(), request, receive, "admin");
             default:
                 throw new UnsupportedOperationException();
         }

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoKeys.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoKeys.java
@@ -36,6 +36,7 @@ public class MongoKeys {
     public static final String PASSWORD            = "password";
     public static final String DATABASE            = "database";
     public static final String CLIENT_NAME         = "clientName";
+    public static final String DRIVER_VERSION      = "driverVersion";
     // for pool
     public static final String MAX_TOTAL           = "maxTotal";
     public static final String MAX_IDLE            = "maxIdle";

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoKeys.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoKeys.java
@@ -21,8 +21,9 @@ public class MongoKeys {
 
     //
     public static final String ADAPTER_NAME        = JdbcDriver.P_ADAPTER_NAME;
-    public static final String ADAPTER_NAME_VALUE  = "mongodb";
-    public static final String START_URL           = JdbcDriver.START_URL + ADAPTER_NAME_VALUE + ":";
+    public static final String MONGO4_ADAPTER_NAME = "mongodb4";
+    public static final String MONGO5_ADAPTER_NAME = "mongodb5";
+    public static final String LEGACY_START_URL    = JdbcDriver.START_URL + "mongodb:";
     public static final String DEFAULT_CLIENT_NAME = "MongoDB-JDBC-Client";
 
     // for call

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoSessionProvider.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoSessionProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.clougence.clouddm.ds.mongodb.execute.jdbc;
+
+import org.bson.Document;
+
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoClient;
+
+class MongoSessionProvider {
+
+    private static final String LEGACY_DRIVER_VERSION = "4.7.2";
+
+    private final MongoClient   client;
+    private final String        driverVersion;
+    private Boolean             sessionSupported;
+
+    MongoSessionProvider(MongoClient client, String driverVersion){
+        this.client = client;
+        this.driverVersion = driverVersion;
+    }
+
+    public synchronized ClientSession startSession() {
+        if (this.sessionSupported == null) {
+            this.sessionSupported = detectSessionSupport();
+        }
+        if (!this.sessionSupported) {
+            return null;
+        }
+        return this.client.startSession();
+    }
+
+    private boolean detectSessionSupport() {
+        if (!LEGACY_DRIVER_VERSION.equals(this.driverVersion)) {
+            return true;
+        }
+
+        Document hello = this.client.getDatabase("admin").runCommand(new Document("isMaster", 1));
+        return hello.get("logicalSessionTimeoutMinutes") != null;
+    }
+}

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoUtils.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoUtils.java
@@ -24,6 +24,8 @@ import org.bson.Document;
 import com.clougence.drivers.adapter.*;
 import com.clougence.utils.CollectionUtils;
 import com.clougence.utils.future.CgFuture;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoDatabase;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,6 +34,13 @@ class MongoUtils {
 
     protected static final JdbcColumn       RESULT_COLUMN = new JdbcColumn("RESULT", AdapterType.String, "", "", "");
     protected static final List<JdbcColumn> RESULT        = Collections.singletonList(RESULT_COLUMN);
+
+    protected static Document runCommand(MongoDatabase database, ClientSession session, Document command) {
+        if (session == null) {
+            return database.runCommand(command);
+        }
+        return database.runCommand(session, command);
+    }
 
     public static CgFuture<?> completed(CgFuture<Object> sync) {
         sync.completed(true);
@@ -141,31 +150,40 @@ class MongoUtils {
 
     protected static CgFuture<?> handleResult(CgFuture<Object> sync, AdapterRequest request, AdapterReceive receive, MongoResultBuffer buffer,
                                               Iterator<Document> it) throws SQLException, IOException {
-        Set<String> keySet = new LinkedHashSet<>();
+        try {
+            Set<String> keySet = new LinkedHashSet<>();
 
-        long maxRows = request.getMaxRows();
-        int affectRows = 0;
-        while (it.hasNext()) {
-            Document document = it.next();
-            buffer.add(document);
-            keySet.addAll(document.keySet());
+            long maxRows = request.getMaxRows();
+            int affectRows = 0;
+            while (it.hasNext()) {
+                Document document = it.next();
+                buffer.add(document);
+                keySet.addAll(document.keySet());
 
-            affectRows++;
-            if (maxRows > 0 && affectRows >= maxRows) {
-                break;
+                affectRows++;
+                if (maxRows > 0 && affectRows >= maxRows) {
+                    break;
+                }
             }
+            buffer.finish();
+
+            List<JdbcColumn> columns = new ArrayList<>();
+            for (String key : keySet) {
+                columns.add(new JdbcColumn(key, AdapterType.String, "", "", ""));
+            }
+
+            MongoResultCursor cursor = new MongoResultCursor(request, columns, buffer);
+
+            receive.responseResult(request, cursor);
+            return completed(sync);
+        } catch (SQLException | IOException | RuntimeException e) {
+            try {
+                buffer.close();
+            } catch (IOException closeException) {
+                e.addSuppressed(closeException);
+            }
+            throw e;
         }
-        buffer.finish();
-
-        List<JdbcColumn> columns = new ArrayList<>();
-        for (String key : keySet) {
-            columns.add(new JdbcColumn(key, AdapterType.String, "", "", ""));
-        }
-
-        MongoResultCursor cursor = new MongoResultCursor(request, columns,buffer);
-
-        receive.responseResult(request, cursor);
-        return completed(sync);
     }
 
 }

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/resources/META-INF/clougence/drivers.xml
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/resources/META-INF/clougence/drivers.xml
@@ -1,38 +1,38 @@
 <drivers>
     <driver driverFamily="MongoDB Driver" version="5.9.0">
-        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory</driverName>
+        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.Mongo5JdbcDsFactory</driverName>
         <resource type="maven">org.mongodb:mongodb-driver-sync:5.9.0</resource>
     </driver>
     <driver driverFamily="MongoDB Driver" version="5.6.5">
-        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory</driverName>
+        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.Mongo5JdbcDsFactory</driverName>
         <resource type="maven">org.mongodb:mongodb-driver-sync:5.6.5</resource>
     </driver>
     <driver driverFamily="MongoDB Driver" version="5.5.2">
-        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory</driverName>
+        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.Mongo5JdbcDsFactory</driverName>
         <resource type="maven">org.mongodb:mongodb-driver-sync:5.5.2</resource>
     </driver>
     <driver driverFamily="MongoDB Driver" version="5.4.0">
-        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory</driverName>
+        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.Mongo5JdbcDsFactory</driverName>
         <resource type="maven">org.mongodb:mongodb-driver-sync:5.4.0</resource>
     </driver>
     <driver driverFamily="MongoDB Driver" version="5.3.1">
-        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory</driverName>
+        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.Mongo5JdbcDsFactory</driverName>
         <resource type="maven">org.mongodb:mongodb-driver-sync:5.3.1</resource>
     </driver>
     <driver driverFamily="MongoDB Driver" version="5.2.1">
-        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory</driverName>
+        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.Mongo5JdbcDsFactory</driverName>
         <resource type="maven">org.mongodb:mongodb-driver-sync:5.2.1</resource>
     </driver>
     <driver driverFamily="MongoDB Driver" version="5.1.4">
-        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory</driverName>
+        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.Mongo5JdbcDsFactory</driverName>
         <resource type="maven">org.mongodb:mongodb-driver-sync:5.1.4</resource>
     </driver>
     <driver driverFamily="MongoDB Driver" version="5.0.1">
-        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory</driverName>
+        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.Mongo5JdbcDsFactory</driverName>
         <resource type="maven">org.mongodb:mongodb-driver-sync:5.0.1</resource>
     </driver>
     <driver driverFamily="MongoDB Driver" version="4.7.2">
-        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory</driverName>
+        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.Mongo4JdbcDsFactory</driverName>
         <resource type="maven">org.mongodb:mongodb-driver-sync:4.7.2</resource>
     </driver>
 </drivers>

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/resources/META-INF/clougence/drivers.xml
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/resources/META-INF/clougence/drivers.xml
@@ -1,4 +1,8 @@
 <drivers>
+    <driver driverFamily="MongoDB Driver" version="5.9.0">
+        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory</driverName>
+        <resource type="maven">org.mongodb:mongodb-driver-sync:5.9.0</resource>
+    </driver>
     <driver driverFamily="MongoDB Driver" version="5.6.5">
         <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory</driverName>
         <resource type="maven">org.mongodb:mongodb-driver-sync:5.6.5</resource>
@@ -26,5 +30,9 @@
     <driver driverFamily="MongoDB Driver" version="5.0.1">
         <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory</driverName>
         <resource type="maven">org.mongodb:mongodb-driver-sync:5.0.1</resource>
+    </driver>
+    <driver driverFamily="MongoDB Driver" version="4.7.2">
+        <driverName>com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory</driverName>
+        <resource type="maven">org.mongodb:mongodb-driver-sync:4.7.2</resource>
     </driver>
 </drivers>

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/resources/META-INF/services/com.clougence.drivers.DsFactory
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/resources/META-INF/services/com.clougence.drivers.DsFactory
@@ -1,1 +1,2 @@
-com.clougence.clouddm.ds.mongodb.execute.dsfactory.MongoJdbcDsFactory
+com.clougence.clouddm.ds.mongodb.execute.dsfactory.Mongo4JdbcDsFactory
+com.clougence.clouddm.ds.mongodb.execute.dsfactory.Mongo5JdbcDsFactory

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/resources/META-INF/services/com.clougence.drivers.adapter.AdapterFactory
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/resources/META-INF/services/com.clougence.drivers.adapter.AdapterFactory
@@ -1,1 +1,0 @@
-com.clougence.clouddm.ds.mongodb.execute.jdbc.MongoConnectionFactory

--- a/backend/clouddm-utils/cg-drivers/src/main/java/com/clougence/drivers/adapter/JdbcConnection.java
+++ b/backend/clouddm-utils/cg-drivers/src/main/java/com/clougence/drivers/adapter/JdbcConnection.java
@@ -31,18 +31,10 @@ class JdbcConnection implements Connection {
     private final TransactionSupport txSupport;
 
     JdbcConnection(String jdbcUrl, Properties properties) throws SQLException{
-        this(jdbcUrl, properties, null);
-    }
-
-    JdbcConnection(String jdbcUrl, Properties properties, AdapterFactory factory) throws SQLException{
         Objects.requireNonNull(properties, "parameter properties is null.");
         String adapter = properties.getProperty(JdbcDriver.P_ADAPTER_NAME);
 
-        if (factory == null) {
-            factory = AdapterManager.lookup(adapter);
-        } else if (!Objects.equals(adapter, factory.getAdapterName())) {
-            throw new SQLException("adapter factory name does not match jdbc url, adapter=" + adapter + ", factory=" + factory.getAdapterName());
-        }
+        AdapterFactory factory = AdapterManager.lookup(adapter);
         TypeSupport ts = factory.createTypeSupport(properties);
 
         this.connection = factory.createConnection(this, jdbcUrl, properties);

--- a/backend/clouddm-utils/cg-drivers/src/main/java/com/clougence/drivers/adapter/JdbcConnection.java
+++ b/backend/clouddm-utils/cg-drivers/src/main/java/com/clougence/drivers/adapter/JdbcConnection.java
@@ -15,7 +15,7 @@
  */
 package com.clougence.drivers.adapter;
 
-import java.io.Closeable;
+import java.io.IOException;
 import java.sql.*;
 import java.util.*;
 import java.util.concurrent.Executor;
@@ -23,18 +23,26 @@ import java.util.concurrent.Executor;
 import com.clougence.drivers.adapter.lob.JdbcBob;
 import com.clougence.drivers.adapter.lob.JdbcCob;
 
-class JdbcConnection implements Connection, Closeable {
+class JdbcConnection implements Connection {
 
-    private boolean                  closed = false;
+    private volatile boolean         closed = false;
     private final AdapterConnection  connection;
     private final TypeSupport        typeSupport;
     private final TransactionSupport txSupport;
 
     JdbcConnection(String jdbcUrl, Properties properties) throws SQLException{
+        this(jdbcUrl, properties, null);
+    }
+
+    JdbcConnection(String jdbcUrl, Properties properties, AdapterFactory factory) throws SQLException{
         Objects.requireNonNull(properties, "parameter properties is null.");
         String adapter = properties.getProperty(JdbcDriver.P_ADAPTER_NAME);
 
-        AdapterFactory factory = AdapterManager.lookup(adapter);
+        if (factory == null) {
+            factory = AdapterManager.lookup(adapter);
+        } else if (!Objects.equals(adapter, factory.getAdapterName())) {
+            throw new SQLException("adapter factory name does not match jdbc url, adapter=" + adapter + ", factory=" + factory.getAdapterName());
+        }
         TypeSupport ts = factory.createTypeSupport(properties);
 
         this.connection = factory.createConnection(this, jdbcUrl, properties);
@@ -56,10 +64,14 @@ class JdbcConnection implements Connection, Closeable {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() throws SQLException {
         if (!this.isClosed()) {
             this.closed = true;
-            AdapterConnManager.removeConnection(this.connection);
+            try {
+                this.connection.close();
+            } catch (IOException e) {
+                throw new SQLException("failed to close adapter connection", e);
+            }
         }
     }
 

--- a/backend/clouddm-utils/cg-drivers/src/main/java/com/clougence/drivers/adapter/JdbcDriver.java
+++ b/backend/clouddm-utils/cg-drivers/src/main/java/com/clougence/drivers/adapter/JdbcDriver.java
@@ -19,7 +19,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -62,15 +61,6 @@ public class JdbcDriver implements java.sql.Driver {
             return null;
         }
         return new JdbcConnection(url, properties);
-    }
-
-    public Connection connect(String url, Properties info, AdapterFactory factory) throws SQLException {
-        Objects.requireNonNull(factory, "parameter factory is null.");
-        Properties properties = parseURL(url, info);
-        if (properties == null) {
-            return null;
-        }
-        return new JdbcConnection(url, properties, factory);
     }
 
     @Override

--- a/backend/clouddm-utils/cg-drivers/src/main/java/com/clougence/drivers/adapter/JdbcDriver.java
+++ b/backend/clouddm-utils/cg-drivers/src/main/java/com/clougence/drivers/adapter/JdbcDriver.java
@@ -19,6 +19,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -61,6 +62,15 @@ public class JdbcDriver implements java.sql.Driver {
             return null;
         }
         return new JdbcConnection(url, properties);
+    }
+
+    public Connection connect(String url, Properties info, AdapterFactory factory) throws SQLException {
+        Objects.requireNonNull(factory, "parameter factory is null.");
+        Properties properties = parseURL(url, info);
+        if (properties == null) {
+            return null;
+        }
+        return new JdbcConnection(url, properties, factory);
     }
 
     @Override

--- a/package/docker/built-in-drivers.xml
+++ b/package/docker/built-in-drivers.xml
@@ -28,8 +28,8 @@
     <driver driverFamily="SQL Server JDBC Driver" version="13.4.0">
         <resource type="maven">com.microsoft.sqlserver:mssql-jdbc:13.4.0.jre8</resource>
     </driver>
-    <driver driverFamily="MongoDB Driver" version="5.6.5">
-        <resource type="maven">org.mongodb:mongodb-driver-sync:5.6.5</resource>
+    <driver driverFamily="MongoDB Driver" version="5.9.0">
+        <resource type="maven">org.mongodb:mongodb-driver-sync:5.9.0</resource>
     </driver>
     <driver driverFamily="ClickHouse JDBC" version="0.9.7">
         <resource type="maven">com.clickhouse:clickhouse-jdbc:0.9.7</resource>


### PR DESCRIPTION
## Summary

Add a legacy MongoDB driver path so CloudDM can connect to MongoDB 4.0-era deployments while retaining the modern 5.9.0 driver path. The change also resolves cross-version adapter, session, timeout, connection, and cursor lifecycle incompatibilities discovered during implementation.

## Related Issues

Closes #140

## Type of Change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- add MongoDB Java driver 4.7.2 alongside 5.9.0 and expose both versions through the driver catalog
- propagate the selected driver version into the MongoDB adapter and bind the factory to the selected driver binding
- detect legacy server session capability and run commands without an explicit session when unsupported
- configure connection and socket timeouts through the MongoDB URI to avoid cross-version API signature mismatches
- make JDBC and adapter connection shutdown release the underlying client and unregister the adapter connection
- support multi-batch cursor reads and make cursor cleanup best-effort so cleanup failures cannot overwrite successful query results

## Test Plan

- [ ] Not tested (explain why below)
- [x] Unit tests
- [x] Integration tests
- [x] Frontend lint / build
- [x] Backend build
- [x] Manual verification

Details:

```text
PASS  ./gradlew :cg-drivers:test :ds-mongodb:test :ds-redis:test
PASS  ./all_build.sh plugin ds-mongodb
PASS  ./all_build.sh
PASS  MongoDB Java driver 4.7.2 and 5.9.0 runtime smoke checks
PASS  Injected killCursors failure with Statement.setMaxRows(1); the query result remained available
PASS  Chrome query against MongoDB 8.3 with 1,200 documents; 1,000 rewritten-limit rows returned
PASS  IDEA restart: Embedded worker plugins finished; /healthcheck = ok
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [ ] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
