### PR TITLE
fix(report): isolate installation report server configuration

### DIFF
--- a/backend/clouddm-boot/boot-alone/src/main/resources/alone.properties
+++ b/backend/clouddm-boot/boot-alone/src/main/resources/alone.properties
@@ -38,4 +38,4 @@ dw.sidecar.export.max-fetch-count=-1
 #clougence.rdp.deploy.context-path=http://dm-tongji.clougence.com/
 #clougence.rdp.login.cookie.domain=dm-tongji.clougence.com
 clouddm.upgrade.server=127.0.0.1:8113
-clouddm.installation.report.server=127.0.0.1:8113
+clouddm.report.server=127.0.0.1:8113

--- a/backend/clouddm-boot/boot-alone/src/main/resources/alone.properties
+++ b/backend/clouddm-boot/boot-alone/src/main/resources/alone.properties
@@ -38,3 +38,4 @@ dw.sidecar.export.max-fetch-count=-1
 #clougence.rdp.deploy.context-path=http://dm-tongji.clougence.com/
 #clougence.rdp.login.cookie.domain=dm-tongji.clougence.com
 clouddm.upgrade.server=127.0.0.1:8113
+clouddm.installation.report.server=127.0.0.1:8113

--- a/backend/clouddm-boot/boot-alone/src/main/resources/default_alone.properties
+++ b/backend/clouddm-boot/boot-alone/src/main/resources/default_alone.properties
@@ -42,6 +42,6 @@ clougence.rdp.dsconfig.validate.enable=false
 ##                                           CloudDM Config ##
 ##############################################################
 clouddm.upgrade.server=server.cdmgr.com
-clouddm.installation.report.server=server.cdmgr.com
+clouddm.report.server=server.cdmgr.com
 clouddm.consolejob.engine.async.threadpool=10
 console.config.cross.origins=*

--- a/backend/clouddm-boot/boot-alone/src/main/resources/default_alone.properties
+++ b/backend/clouddm-boot/boot-alone/src/main/resources/default_alone.properties
@@ -42,5 +42,6 @@ clougence.rdp.dsconfig.validate.enable=false
 ##                                           CloudDM Config ##
 ##############################################################
 clouddm.upgrade.server=server.cdmgr.com
+clouddm.installation.report.server=server.cdmgr.com
 clouddm.consolejob.engine.async.threadpool=10
 console.config.cross.origins=*

--- a/backend/clouddm-boot/boot-console/src/main/resources/console.properties
+++ b/backend/clouddm-boot/boot-console/src/main/resources/console.properties
@@ -34,3 +34,4 @@ editor.query.test=false
 #clougence.rdp.deploy.context-path=http://dm-tongji.clougence.com/
 #clougence.rdp.login.cookie.domain=dm-tongji.clougence.com
 clouddm.upgrade.server=127.0.0.1:8113
+clouddm.installation.report.server=127.0.0.1:8113

--- a/backend/clouddm-boot/boot-console/src/main/resources/console.properties
+++ b/backend/clouddm-boot/boot-console/src/main/resources/console.properties
@@ -34,4 +34,4 @@ editor.query.test=false
 #clougence.rdp.deploy.context-path=http://dm-tongji.clougence.com/
 #clougence.rdp.login.cookie.domain=dm-tongji.clougence.com
 clouddm.upgrade.server=127.0.0.1:8113
-clouddm.installation.report.server=127.0.0.1:8113
+clouddm.report.server=127.0.0.1:8113

--- a/backend/clouddm-boot/boot-console/src/main/resources/default_console.properties
+++ b/backend/clouddm-boot/boot-console/src/main/resources/default_console.properties
@@ -42,6 +42,6 @@ clougence.rdp.dsconfig.validate.enable=false
 ##                                           CloudDM Config ##
 ##############################################################
 clouddm.upgrade.server=server.cdmgr.com
-clouddm.installation.report.server=server.cdmgr.com
+clouddm.report.server=server.cdmgr.com
 clouddm.consolejob.engine.async.threadpool=10
 console.config.cross.origins=*

--- a/backend/clouddm-boot/boot-console/src/main/resources/default_console.properties
+++ b/backend/clouddm-boot/boot-console/src/main/resources/default_console.properties
@@ -42,5 +42,6 @@ clougence.rdp.dsconfig.validate.enable=false
 ##                                           CloudDM Config ##
 ##############################################################
 clouddm.upgrade.server=server.cdmgr.com
+clouddm.installation.report.server=server.cdmgr.com
 clouddm.consolejob.engine.async.threadpool=10
 console.config.cross.origins=*

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/config/ConsoleConfig.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/config/ConsoleConfig.java
@@ -48,6 +48,8 @@ public class ConsoleConfig {
 
     @Value("${clouddm.upgrade.server:server.cdmgr.com}")
     private String         upgradeServer;
+    @Value("${clouddm.installation.report.server:server.cdmgr.com}")
+    private String         installationReportServer;
 
     // for rsocket
     @Value("${clouddm.rsocket.dns:clouddm_console}")

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/config/ConsoleConfig.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/config/ConsoleConfig.java
@@ -48,8 +48,8 @@ public class ConsoleConfig {
 
     @Value("${clouddm.upgrade.server:server.cdmgr.com}")
     private String         upgradeServer;
-    @Value("${clouddm.installation.report.server:server.cdmgr.com}")
-    private String         installationReportServer;
+    @Value("${clouddm.report.server:server.cdmgr.com}")
+    private String         reportServer;
 
     // for rsocket
     @Value("${clouddm.rsocket.dns:clouddm_console}")

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/service/system/InstallationReportStarter.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/service/system/InstallationReportStarter.java
@@ -80,7 +80,7 @@ public class InstallationReportStarter implements UnifiedPostConstruct {
     private boolean report(String version, String type) {
         try {
             String body = JsonUtils.toJson(Map.of("version", version, "type", type));
-            String reportUrl = "https://" + this.config.getInstallationReportServer() + INSTALLATION_REPORT_PATH;
+            String reportUrl = "https://" + this.config.getReportServer() + INSTALLATION_REPORT_PATH;
             HttpRequest request = HttpRequest.newBuilder(URI.create(reportUrl))
                 .timeout(Duration.ofSeconds(5))
                 .header("Content-Type", "application/json")

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/service/system/InstallationReportStarter.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/service/system/InstallationReportStarter.java
@@ -80,7 +80,7 @@ public class InstallationReportStarter implements UnifiedPostConstruct {
     private boolean report(String version, String type) {
         try {
             String body = JsonUtils.toJson(Map.of("version", version, "type", type));
-            String reportUrl = "https://" + this.config.getUpgradeServer() + INSTALLATION_REPORT_PATH;
+            String reportUrl = "https://" + this.config.getInstallationReportServer() + INSTALLATION_REPORT_PATH;
             HttpRequest request = HttpRequest.newBuilder(URI.create(reportUrl))
                 .timeout(Duration.ofSeconds(5))
                 .header("Content-Type", "application/json")

--- a/package/docker/shared/alone/alone.properties
+++ b/package/docker/shared/alone/alone.properties
@@ -39,3 +39,4 @@ dw.sidecar.export.max-fetch-count=-1
 #clougence.rdp.deploy.context-path=http://dm-tongji.clougence.com/
 #clougence.rdp.login.cookie.domain=dm-tongji.clougence.com
 clouddm.upgrade.server=server.cdmgr.com
+clouddm.installation.report.server=server.cdmgr.com

--- a/package/docker/shared/alone/alone.properties
+++ b/package/docker/shared/alone/alone.properties
@@ -39,4 +39,4 @@ dw.sidecar.export.max-fetch-count=-1
 #clougence.rdp.deploy.context-path=http://dm-tongji.clougence.com/
 #clougence.rdp.login.cookie.domain=dm-tongji.clougence.com
 clouddm.upgrade.server=server.cdmgr.com
-clouddm.installation.report.server=server.cdmgr.com
+clouddm.report.server=server.cdmgr.com


### PR DESCRIPTION
## Summary

Use a dedicated server configuration for installation and upgrade reports.

Installation reporting reused `clouddm.upgrade.server`, so persisted local upgrade-server overrides could redirect reports away from `server.cdmgr.com`. The report flow now reads `clouddm.installation.report.server` while version checks keep using the existing upgrade key.

## Related Issues

None

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Added `clouddm.installation.report.server` with `server.cdmgr.com` as the production and Docker default.
- Kept local development report configuration on `127.0.0.1:8113`.
- Updated `InstallationReportStarter` to use the dedicated report server.
- Preserved `clouddm.upgrade.server` for version difference and release-note requests.

## Test Plan

- [ ] Not tested (explain why below)
- [x] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [x] Backend build
- [ ] Manual verification

Details:

```text
cd backend
./gradlew :cgdm-console:test :boot-alone:test :boot-console:test --parallel --max-workers=8

BUILD SUCCESSFUL in 4s
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [ ] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
