### PR TITLE
fix(init): register plugin global services

### DIFF
--- a/backend/clouddm-boot/boot-initialization/src/main/java/com/clougence/clouddm/init/InitTaskApplication.java
+++ b/backend/clouddm-boot/boot-initialization/src/main/java/com/clougence/clouddm/init/InitTaskApplication.java
@@ -25,6 +25,9 @@ import com.clougence.clouddm.console.web.component.auth.impl.DmAuthLabelServiceI
 import com.clougence.clouddm.console.web.global.i18n.DmI18nUtils;
 import com.clougence.clouddm.console.web.service.envparam.DmEnvParamServiceImpl;
 import com.clougence.clouddm.console.web.service.login.LoginMFAServiceImpl;
+import com.clougence.clouddm.console.web.service.sdk.ConsoleCacheServiceImpl;
+import com.clougence.clouddm.console.web.service.sdk.ConsolePluginConfigServiceImpl;
+import com.clougence.clouddm.console.web.service.sdk.ConsoleQueryConstraintServiceImpl;
 import com.clougence.clouddm.console.web.service.security.CheckRulesServiceImpl;
 import com.clougence.clouddm.init.constant.I18nInitFieldKeys;
 
@@ -36,7 +39,8 @@ import com.clougence.clouddm.init.constant.I18nInitFieldKeys;
 @ComponentScan(basePackages = { "com.clougence.clouddm.init.component.flyway", "com.clougence.clouddm.init.component.fixtasks",
                                 "com.clougence.clouddm.console.web.component.config", "com.clougence.clouddm.base", "com.clougence.clouddm.platform",
                                 "com.clougence.clouddm.sdk", "com.clougence.clouddm.api" })
-@Import({ DmAuthLabelServiceImpl.class, DmEnvParamServiceImpl.class, LoginMFAServiceImpl.class, CheckRulesServiceImpl.class })
+@Import({ DmAuthLabelServiceImpl.class, DmEnvParamServiceImpl.class, LoginMFAServiceImpl.class, CheckRulesServiceImpl.class,
+          ConsoleCacheServiceImpl.class, ConsolePluginConfigServiceImpl.class, ConsoleQueryConstraintServiceImpl.class })
 public class InitTaskApplication {
 
     @Bean

--- a/backend/clouddm-boot/boot-initialization/src/main/java/com/clougence/clouddm/init/component/fixtasks/InitConsolePluginLoader.java
+++ b/backend/clouddm-boot/boot-initialization/src/main/java/com/clougence/clouddm/init/component/fixtasks/InitConsolePluginLoader.java
@@ -20,15 +20,34 @@ import java.io.File;
 import org.springframework.stereotype.Service;
 
 import com.clougence.clouddm.api.common.GlobalConfUtils;
+import com.clougence.clouddm.console.web.service.sdk.ConsoleCacheServiceImpl;
+import com.clougence.clouddm.console.web.service.sdk.ConsolePluginConfigServiceImpl;
 import com.clougence.clouddm.platform.plugin.PluginLoadHelper;
 import com.clougence.clouddm.platform.plugin.PluginManager;
 import com.clougence.clouddm.sdk.security.auth.AuthInfoSpi;
+import com.clougence.clouddm.sdk.service.cache.CacheService;
+import com.clougence.clouddm.sdk.service.config.ConfigService;
+import com.clougence.clouddm.sdk.sql.column.QueryConstraintService;
 import com.clougence.utils.CollectionUtils;
+
+import jakarta.annotation.Resource;
 
 @Service
 public class InitConsolePluginLoader {
 
+    @Resource
+    private ConsoleCacheServiceImpl cacheService;
+    @Resource
+    private ConsolePluginConfigServiceImpl configService;
+    @Resource
+    private QueryConstraintService  queryConstraintService;
+
     public void loadPlugin(ClassLoader parentClassLoader) {
+        this.cacheService.init();
+        PluginManager.putService(CacheService.class, this.cacheService);
+        PluginManager.putService(ConfigService.class, this.configService);
+        PluginManager.putService(QueryConstraintService.class, this.queryConstraintService);
+
         if (CollectionUtils.isNotEmpty(PluginManager.findSpi(AuthInfoSpi.class))) {
             return;
         }


### PR DESCRIPTION
## Summary

Register the security rules plugin's required global services before loading plugins in the temporary initialization context. This prevents `SecRulesCheckerServiceProvider` from being constructed with a null `CacheService` during post-migration fix tasks.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Import the lightweight console cache, plugin configuration, and query constraint service implementations into `InitTaskApplication`.
- Register `CacheService`, `ConfigService`, and `QueryConstraintService` with `PluginManager` before loading plugins.
- Inject `ConsolePluginConfigServiceImpl` explicitly to avoid ambiguity with `SidecarConfigServiceImpl` in standalone mode.

## Test Plan

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [x] Backend build
- [x] Manual verification

Details:

```text
./gradlew :boot-initialization:test :boot-alone:compileJava
BUILD SUCCESSFUL

./gradlew :boot-alone:run
Tomcat started on port 8222
Started DmAloneLauncher
Alone All Context Inited
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [x] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
