### PR TITLE
fix(sql-engine): limit lineage analysis to MySQL

### DIFF
--- a/backend/clouddm-platform/cgdm-plugin-sdk/src/main/java/com/clougence/clouddm/sdk/sql/analysis/lineage/LineageAnalysisSpi.java
+++ b/backend/clouddm-platform/cgdm-plugin-sdk/src/main/java/com/clougence/clouddm/sdk/sql/analysis/lineage/LineageAnalysisSpi.java
@@ -21,6 +21,9 @@ import com.clougence.clouddm.sdk.Spi;
 
 public interface LineageAnalysisSpi extends Spi {
 
+    /** Lineage analyzer used when a SQL engine does not currently expose lineage analysis. */
+    LineageAnalysisSpi EMPTY = (sql, context) -> List.of();
+
     /**
      * Analyzes every result column in the query.
      *

--- a/backend/clouddm-plugins/clouddm-ds/ds-adb/src/main/java/com/clougence/clouddm/ds/ads/sql/ads4my/AdsMySqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-adb/src/main/java/com/clougence/clouddm/ds/ads/sql/ads4my/AdsMySqlEngineSpi.java
@@ -16,7 +16,6 @@
 package com.clougence.clouddm.ds.ads.sql.ads4my;
 
 import com.clougence.clouddm.ds.ads.sql.ads4my.analysis.behavior.AdsMyBehaviorAnalysisSpi;
-import com.clougence.clouddm.ds.ads.sql.ads4my.analysis.lineage.AdsMyLineageAnalysisSpi;
 import com.clougence.clouddm.ds.ads.sql.ads4my.analysis.security.AdsMySecDomainResolveSpi;
 import com.clougence.clouddm.ds.ads.sql.ads4my.editor.rewrite.AdbRewriteSpi;
 import com.clougence.clouddm.ds.ads.sql.ads4my.parser.AdsMyDslProvider;
@@ -45,7 +44,7 @@ public class AdsMySqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new AdsMySplitAnalysisSpi();
         this.secDomainResolveSpi = new AdsMySecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new AdsMyBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new AdsMyLineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = new AdbRewriteSpi();
     }
 

--- a/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/sql/ChSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/sql/ChSqlEngineSpi.java
@@ -16,7 +16,6 @@
 package com.clougence.clouddm.ds.clickhouse.sql;
 
 import com.clougence.clouddm.ds.clickhouse.sql.analysis.behavior.ChBehaviorAnalysisSpi;
-import com.clougence.clouddm.ds.clickhouse.sql.analysis.lineage.ChLineageAnalysisSpi;
 import com.clougence.clouddm.ds.clickhouse.sql.analysis.security.ChSecDomainResolveSpi;
 import com.clougence.clouddm.ds.clickhouse.sql.editor.rewrite.ChRewriteSpi;
 import com.clougence.clouddm.ds.clickhouse.sql.parser.ChSplitAnalysisSpi;
@@ -45,7 +44,7 @@ public class ChSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new ChSplitAnalysisSpi();
         this.secDomainResolveSpi = new ChSecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new ChBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new ChLineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = new ChRewriteSpi();
     }
 

--- a/backend/clouddm-plugins/clouddm-ds/ds-dameng/src/main/java/com/clougence/clouddm/ds/dameng/sql/DmSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-dameng/src/main/java/com/clougence/clouddm/ds/dameng/sql/DmSqlEngineSpi.java
@@ -16,7 +16,6 @@
 package com.clougence.clouddm.ds.dameng.sql;
 
 import com.clougence.clouddm.ds.dameng.sql.analysis.behavior.DmBehaviorAnalysisSpi;
-import com.clougence.clouddm.ds.dameng.sql.analysis.lineage.DmLineageAnalysisSpi;
 import com.clougence.clouddm.ds.dameng.sql.analysis.security.DmSecDomainResolveSpi;
 import com.clougence.clouddm.ds.dameng.sql.parser.DmDslProvider;
 import com.clougence.clouddm.ds.dameng.sql.parser.DmSplitAnalysisSpi;
@@ -42,7 +41,7 @@ public class DmSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new DmSplitAnalysisSpi();
         this.secDomainResolveSpi = new DmSecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new DmBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new DmLineageAnalysisSpi();
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
     }
 
     @Override

--- a/backend/clouddm-plugins/clouddm-ds/ds-gauss/src/main/java/com/clougence/clouddm/ds/gauss/sql/GaussSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-gauss/src/main/java/com/clougence/clouddm/ds/gauss/sql/GaussSqlEngineSpi.java
@@ -16,7 +16,6 @@
 package com.clougence.clouddm.ds.gauss.sql;
 
 import com.clougence.clouddm.ds.gauss.sql.analysis.behavior.GaussBehaviorAnalysisSpi;
-import com.clougence.clouddm.ds.gauss.sql.analysis.lineage.GaussLineageAnalysisSpi;
 import com.clougence.clouddm.ds.gauss.sql.analysis.security.GaussSecDomainResolveSpi;
 import com.clougence.clouddm.ds.gauss.sql.editor.rewrite.GaussRewriteSpi;
 import com.clougence.clouddm.ds.gauss.sql.parser.GaussDslProvider;
@@ -45,7 +44,7 @@ public class GaussSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new GaussSplitAnalysisSpi();
         this.secDomainResolveSpi = new GaussSecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new GaussBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new GaussLineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = new GaussRewriteSpi();
     }
 

--- a/backend/clouddm-plugins/clouddm-ds/ds-hana/src/main/java/com/clougence/clouddm/ds/hana/sql/HanaSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-hana/src/main/java/com/clougence/clouddm/ds/hana/sql/HanaSqlEngineSpi.java
@@ -40,7 +40,7 @@ public class HanaSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new HanaSplitAnalysisSpi();
         this.secDomainResolveSpi = null;
         this.behaviorAnalysisSpi = new HanaBehaviorAnalysisSpi(splitAnalysisSpi);
-        this.lineageAnalysisSpi = null;
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = null;
     }
 

--- a/backend/clouddm-plugins/clouddm-ds/ds-maxcompute/src/main/java/com/clougence/clouddm/ds/maxcompute/sql/McSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-maxcompute/src/main/java/com/clougence/clouddm/ds/maxcompute/sql/McSqlEngineSpi.java
@@ -16,7 +16,6 @@
 package com.clougence.clouddm.ds.maxcompute.sql;
 
 import com.clougence.clouddm.ds.maxcompute.sql.analysis.behavior.McBehaviorAnalysisSpi;
-import com.clougence.clouddm.ds.maxcompute.sql.analysis.lineage.McLineageAnalysisSpi;
 import com.clougence.clouddm.ds.maxcompute.sql.analysis.security.McSecDomainResolveSpi;
 import com.clougence.clouddm.ds.maxcompute.sql.editor.rewrite.McRewriteSpi;
 import com.clougence.clouddm.ds.maxcompute.sql.parser.McSplitAnalysisSpi;
@@ -45,7 +44,7 @@ public class McSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new McSplitAnalysisSpi();
         this.secDomainResolveSpi = new McSecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new McBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new McLineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = new McRewriteSpi();
     }
 

--- a/backend/clouddm-plugins/clouddm-ds/ds-oceanbase/src/main/java/com/clougence/clouddm/ds/oceanbase/sql/ob4my/ObSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-oceanbase/src/main/java/com/clougence/clouddm/ds/oceanbase/sql/ob4my/ObSqlEngineSpi.java
@@ -16,7 +16,6 @@
 package com.clougence.clouddm.ds.oceanbase.sql.ob4my;
 
 import com.clougence.clouddm.ds.oceanbase.sql.ob4my.analysis.behavior.ObMyBehaviorAnalysisSpi;
-import com.clougence.clouddm.ds.oceanbase.sql.ob4my.analysis.lineage.ObLineageAnalysisSpi;
 import com.clougence.clouddm.ds.oceanbase.sql.ob4my.analysis.security.ObSecDomainResolveSpi;
 import com.clougence.clouddm.ds.oceanbase.sql.ob4my.editor.rewrite.ObRewriteSpi;
 import com.clougence.clouddm.ds.oceanbase.sql.ob4my.parser.ObMyDslProvider;
@@ -45,7 +44,7 @@ public class ObSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new ObSplitAnalysisSpi();
         this.secDomainResolveSpi = new ObSecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new ObMyBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new ObLineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = new ObRewriteSpi();
     }
 

--- a/backend/clouddm-plugins/clouddm-ds/ds-oceanbase/src/main/java/com/clougence/clouddm/ds/oceanbase/sql/ob4ora/ObOraSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-oceanbase/src/main/java/com/clougence/clouddm/ds/oceanbase/sql/ob4ora/ObOraSqlEngineSpi.java
@@ -16,7 +16,6 @@
 package com.clougence.clouddm.ds.oceanbase.sql.ob4ora;
 
 import com.clougence.clouddm.ds.oceanbase.sql.ob4ora.analysis.behavior.ObOraBehaviorAnalysisSpi;
-import com.clougence.clouddm.ds.oceanbase.sql.ob4ora.analysis.lineage.ObForOraLineageAnalysisSpi;
 import com.clougence.clouddm.ds.oceanbase.sql.ob4ora.analysis.security.ObForOraSecDomainResolveSpi;
 import com.clougence.clouddm.ds.oceanbase.sql.ob4ora.parser.ObForOraSplitAnalysisSpi;
 import com.clougence.clouddm.ds.oceanbase.sql.ob4ora.parser.ObOraDslProvider;
@@ -44,7 +43,7 @@ public class ObOraSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new ObForOraSplitAnalysisSpi();
         this.secDomainResolveSpi = new ObForOraSecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new ObOraBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new ObForOraLineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = null;
     }
 

--- a/backend/clouddm-plugins/clouddm-ds/ds-polardb/src/main/java/com/clougence/clouddm/ds/polardb/sql/porx/PorXSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-polardb/src/main/java/com/clougence/clouddm/ds/polardb/sql/porx/PorXSqlEngineSpi.java
@@ -16,7 +16,6 @@
 package com.clougence.clouddm.ds.polardb.sql.porx;
 
 import com.clougence.clouddm.ds.polardb.sql.porx.analysis.behavior.PorXBehaviorAnalysisSpi;
-import com.clougence.clouddm.ds.polardb.sql.porx.analysis.lineage.PorXLineageAnalysisSpi;
 import com.clougence.clouddm.ds.polardb.sql.porx.analysis.security.PorXSecDomainResolveSpi;
 import com.clougence.clouddm.ds.polardb.sql.porx.editor.rewrite.PorXRewriteSpi;
 import com.clougence.clouddm.ds.polardb.sql.porx.parser.PolarXDslProvider;
@@ -45,7 +44,7 @@ public class PorXSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new PorXSplitAnalysisSpi();
         this.secDomainResolveSpi = new PorXSecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new PorXBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new PorXLineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = new PorXRewriteSpi();
     }
 

--- a/backend/clouddm-plugins/clouddm-ds/ds-starrocks/src/main/java/com/clougence/clouddm/ds/starrocks/sql/SrSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-starrocks/src/main/java/com/clougence/clouddm/ds/starrocks/sql/SrSqlEngineSpi.java
@@ -16,7 +16,6 @@
 package com.clougence.clouddm.ds.starrocks.sql;
 
 import com.clougence.clouddm.ds.starrocks.sql.analysis.behavior.SrBehaviorAnalysisSpi;
-import com.clougence.clouddm.ds.starrocks.sql.analysis.lineage.SrLineageAnalysisSpi;
 import com.clougence.clouddm.ds.starrocks.sql.analysis.security.SrSecDomainResolveSpi;
 import com.clougence.clouddm.ds.starrocks.sql.editor.rewrite.SrRewriteSpi;
 import com.clougence.clouddm.ds.starrocks.sql.parser.SrDslProvider;
@@ -45,7 +44,7 @@ public class SrSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new SrSplitAnalysisSpi();
         this.secDomainResolveSpi = new SrSecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new SrBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new SrLineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = new SrRewriteSpi();
     }
 

--- a/backend/clouddm-plugins/clouddm-ds/ds-tidb/src/main/java/com/clougence/clouddm/ds/tidb/sql/TiSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-tidb/src/main/java/com/clougence/clouddm/ds/tidb/sql/TiSqlEngineSpi.java
@@ -16,7 +16,6 @@
 package com.clougence.clouddm.ds.tidb.sql;
 
 import com.clougence.clouddm.ds.tidb.sql.analysis.behavior.TiBehaviorAnalysisSpi;
-import com.clougence.clouddm.ds.tidb.sql.analysis.lineage.TiLineageAnalysisSpi;
 import com.clougence.clouddm.ds.tidb.sql.analysis.security.TiSecDomainResolveSpi;
 import com.clougence.clouddm.ds.tidb.sql.editor.rewrite.TiRewriteSpi;
 import com.clougence.clouddm.ds.tidb.sql.parser.TiDBDslProvider;
@@ -45,7 +44,7 @@ public class TiSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new TiSplitAnalysisSpi();
         this.secDomainResolveSpi = new TiSecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new TiBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new TiLineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = new TiRewriteSpi();
     }
 

--- a/backend/clouddm-plugins/clouddm-sql/sql-db2/src/main/java/com/clougence/sql/db2/Db2SqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-db2/src/main/java/com/clougence/sql/db2/Db2SqlEngineSpi.java
@@ -42,7 +42,7 @@ public class Db2SqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new Db2SplitAnalysisSpi();
         this.secDomainResolveSpi = new Db2SecDomainResolveSpi();
         this.behaviorAnalysisSpi = new Db2BehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = null;
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = null;
     }
 

--- a/backend/clouddm-plugins/clouddm-sql/sql-doris/src/main/java/com/clougence/sql/doris/DrSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-doris/src/main/java/com/clougence/sql/doris/DrSqlEngineSpi.java
@@ -25,7 +25,6 @@ import com.clougence.clouddm.sdk.sql.editor.rewrite.RewriteSpi;
 import com.clougence.clouddm.sdk.sql.parser.SplitAnalysisSpi;
 import com.clougence.dslpaser.antlr.DslProvider;
 import com.clougence.sql.doris.analysis.behavior.DrBehaviorAnalysisSpi;
-import com.clougence.sql.doris.analysis.lineage.DrLineageAnalysisSpi;
 import com.clougence.sql.doris.analysis.security.DrSecDomainResolveSpi;
 import com.clougence.sql.doris.editor.rewrite.DrRewriteSpi;
 import com.clougence.sql.doris.parser.DrDslProvider;
@@ -45,7 +44,7 @@ public class DrSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new DrSplitAnalysisSpi();
         this.secDomainResolveSpi = new DrSecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new DrBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new DrLineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = new DrRewriteSpi();
     }
 

--- a/backend/clouddm-plugins/clouddm-sql/sql-iso-sql2003/src/main/java/com/clougence/sql/iso/sql2003/Sql2003SqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-iso-sql2003/src/main/java/com/clougence/sql/iso/sql2003/Sql2003SqlEngineSpi.java
@@ -15,7 +15,6 @@ import com.clougence.clouddm.sdk.sql.editor.rewrite.RewriteSpi;
 import com.clougence.clouddm.sdk.sql.parser.SplitAnalysisSpi;
 import com.clougence.dslpaser.antlr.DslProvider;
 import com.clougence.sql.iso.sql2003.analysis.behavior.Sql2003BehaviorAnalysisSpi;
-import com.clougence.sql.iso.sql2003.analysis.lineage.Sql2003LineageAnalysisSpi;
 import com.clougence.sql.iso.sql2003.analysis.security.Sql2003SecDomainResolveSpi;
 import com.clougence.sql.iso.sql2003.parser.Sql2003DslProvider;
 import com.clougence.sql.iso.sql2003.parser.Sql2003SplitAnalysisSpi;
@@ -33,7 +32,7 @@ public class Sql2003SqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new Sql2003SplitAnalysisSpi();
         this.secDomainResolveSpi = new Sql2003SecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new Sql2003BehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new Sql2003LineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = null;
     }
 

--- a/backend/clouddm-plugins/clouddm-sql/sql-iso-sql92/src/main/java/com/clougence/sql/iso/sql92/Sql92SqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-iso-sql92/src/main/java/com/clougence/sql/iso/sql92/Sql92SqlEngineSpi.java
@@ -15,7 +15,6 @@ import com.clougence.clouddm.sdk.sql.editor.rewrite.RewriteSpi;
 import com.clougence.clouddm.sdk.sql.parser.SplitAnalysisSpi;
 import com.clougence.dslpaser.antlr.DslProvider;
 import com.clougence.sql.iso.sql92.analysis.behavior.Sql92BehaviorAnalysisSpi;
-import com.clougence.sql.iso.sql92.analysis.lineage.Sql92LineageAnalysisSpi;
 import com.clougence.sql.iso.sql92.analysis.security.Sql92SecDomainResolveSpi;
 import com.clougence.sql.iso.sql92.parser.Sql92DslProvider;
 import com.clougence.sql.iso.sql92.parser.Sql92SplitAnalysisSpi;
@@ -33,7 +32,7 @@ public class Sql92SqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new Sql92SplitAnalysisSpi();
         this.secDomainResolveSpi = new Sql92SecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new Sql92BehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new Sql92LineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = null;
     }
 

--- a/backend/clouddm-plugins/clouddm-sql/sql-iso-sql99/src/main/java/com/clougence/sql/iso/sql99/Sql99SqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-iso-sql99/src/main/java/com/clougence/sql/iso/sql99/Sql99SqlEngineSpi.java
@@ -15,7 +15,6 @@ import com.clougence.clouddm.sdk.sql.editor.rewrite.RewriteSpi;
 import com.clougence.clouddm.sdk.sql.parser.SplitAnalysisSpi;
 import com.clougence.dslpaser.antlr.DslProvider;
 import com.clougence.sql.iso.sql99.analysis.behavior.Sql99BehaviorAnalysisSpi;
-import com.clougence.sql.iso.sql99.analysis.lineage.Sql99LineageAnalysisSpi;
 import com.clougence.sql.iso.sql99.analysis.security.Sql99SecDomainResolveSpi;
 import com.clougence.sql.iso.sql99.parser.Sql99DslProvider;
 import com.clougence.sql.iso.sql99.parser.Sql99SplitAnalysisSpi;
@@ -33,7 +32,7 @@ public class Sql99SqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new Sql99SplitAnalysisSpi();
         this.secDomainResolveSpi = new Sql99SecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new Sql99BehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new Sql99LineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = null;
     }
 

--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/MongoSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/MongoSqlEngineSpi.java
@@ -44,7 +44,7 @@ public class MongoSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new MongoSplitAnalysisSpi();
         this.secDomainResolveSpi = new MongoSecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new MongoBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = null;
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = new MongoRewriteSpi();
     }
 

--- a/backend/clouddm-plugins/clouddm-sql/sql-oracle/src/main/java/com/clougence/sql/oracle/OraSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-oracle/src/main/java/com/clougence/sql/oracle/OraSqlEngineSpi.java
@@ -25,7 +25,6 @@ import com.clougence.clouddm.sdk.sql.editor.rewrite.RewriteSpi;
 import com.clougence.clouddm.sdk.sql.parser.SplitAnalysisSpi;
 import com.clougence.dslpaser.antlr.DslProvider;
 import com.clougence.sql.oracle.analysis.behavior.OraBehaviorAnalysisSpi;
-import com.clougence.sql.oracle.analysis.lineage.OraLineageAnalysisSpi;
 import com.clougence.sql.oracle.analysis.security.OraSecDomainResolveSpi;
 import com.clougence.sql.oracle.parser.OraDslProvider;
 import com.clougence.sql.oracle.parser.OraSplitAnalysisSpi;
@@ -44,7 +43,7 @@ public class OraSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new OraSplitAnalysisSpi();
         this.secDomainResolveSpi = new OraSecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new OraBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = new OraLineageAnalysisSpi(metaService);
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = null;
     }
 

--- a/backend/clouddm-plugins/clouddm-sql/sql-postgres/src/main/java/com/clougence/sql/postgres/PgSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-postgres/src/main/java/com/clougence/sql/postgres/PgSqlEngineSpi.java
@@ -29,7 +29,6 @@ import com.clougence.clouddm.sdk.sql.editor.rewrite.RewriteSpi;
 import com.clougence.clouddm.sdk.sql.parser.SplitAnalysisSpi;
 import com.clougence.dslpaser.antlr.DslProvider;
 import com.clougence.sql.postgres.analysis.behavior.PgBehaviorAnalysisSpi;
-import com.clougence.sql.postgres.analysis.lineage.PgLineageAnalysisSpi;
 import com.clougence.sql.postgres.analysis.security.PgSecDomainResolveSpi;
 import com.clougence.sql.postgres.editor.rewrite.PgRewriteSpi;
 import com.clougence.sql.postgres.parser.PgDslProvider;
@@ -44,7 +43,6 @@ public class PgSqlEngineSpi implements SqlEngineSpi {
     private final Map<String, SplitAnalysisSpi>    splitCache     = new ConcurrentHashMap<>();
     private final Map<String, SecDomainResolveSpi> secDomainCache = new ConcurrentHashMap<>();
     private final Map<String, BehaviorAnalysisSpi> behaviorCache  = new ConcurrentHashMap<>();
-    private final Map<String, LineageAnalysisSpi>  lineageCache   = new ConcurrentHashMap<>();
     private final Map<String, RewriteSpi>          rewriteCache   = new ConcurrentHashMap<>();
     private final Map<String, DslProvider>         dslCache       = new ConcurrentHashMap<>();
 
@@ -95,9 +93,7 @@ public class PgSqlEngineSpi implements SqlEngineSpi {
 
     @Override
     public LineageAnalysisSpi lineageAnalysisSpi(SqlParserParameters parameters) {
-        SqlParserParameters parserParameters = SqlParserParameters.nullToEmpty(parameters);
-        String key = parserKey(parserParameters);
-        return lineageCache.computeIfAbsent(key, value -> new PgLineageAnalysisSpi(metaService, resolveVersion(parserParameters)));
+        return LineageAnalysisSpi.EMPTY;
     }
 
     @Override

--- a/backend/clouddm-plugins/clouddm-sql/sql-redis/src/main/java/com/clougence/sql/redis/RedisSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-redis/src/main/java/com/clougence/sql/redis/RedisSqlEngineSpi.java
@@ -43,7 +43,7 @@ public class RedisSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new RedisSplitAnalysisSpi();
         this.secDomainResolveSpi = new RedisSecDomainResolveSpi(metaService);
         this.behaviorAnalysisSpi = new RedisBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = null;
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = null;
     }
 

--- a/backend/clouddm-plugins/clouddm-sql/sql-sqlserver/src/main/java/com/clougence/sql/sqlserver/MsSqlSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-sqlserver/src/main/java/com/clougence/sql/sqlserver/MsSqlSqlEngineSpi.java
@@ -43,7 +43,7 @@ public class MsSqlSqlEngineSpi implements SqlEngineSpi {
         this.splitAnalysisSpi = new MsSqlSplitAnalysisSpi();
         this.secDomainResolveSpi = new MsSqlSecDomainResolveSpi();
         this.behaviorAnalysisSpi = new MsBehaviorAnalysisSpi();
-        this.lineageAnalysisSpi = null;
+        this.lineageAnalysisSpi = LineageAnalysisSpi.EMPTY;
         this.rewriteSpi = null;
     }
 

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,5 +1,5 @@
 #
-org.gradle.jvmargs=-Xmx2048m -Djava.net.preferIPv4Stack=true
+org.gradle.jvmargs=-Xmx8192m -Djava.net.preferIPv4Stack=true
 #
 cg.clouddm.main.version=4.0.1
 #


### PR DESCRIPTION
## Summary

- add a shared empty lineage analyzer for SQL engines that do not currently expose stable lineage support
- temporarily disable lineage analysis for all non-MySQL data sources
- keep the MySQL lineage implementation unchanged
- increase the Gradle daemon heap to 8 GB to prevent OOM while compiling generated parser sources

## Root cause

The non-MySQL lineage implementations are not complete enough for production query analysis. Unsupported select expressions can throw during lineage resolution, for example PostgreSQL `select version()` without an alias, causing otherwise valid queries to fail before execution.

This emergency fix prevents incomplete lineage implementations from affecting normal queries until their behavior and coverage are ready.

## Impact

- non-MySQL queries no longer invoke dialect-specific lineage parsers and receive an empty lineage result
- MySQL continues to use `MyLineageAnalysisSpi`
- SQL behavior analysis, permission checks, and query-rule analysis remain enabled

## Validation

- compiled `cgdm-plugin-sdk` and all affected SQL/data-source modules successfully
- forced regeneration and compilation of the Dameng ANTLR parser with `:ds-dameng:compileJava --rerun-tasks --max-workers=8`
- verified the compiled PostgreSQL engine returns `LineageAnalysisSpi.EMPTY`
- `git diff --check` passed