### PR TITLE
fix(detectrule): prevent concurrent modification in atomic type cache

### DIFF
--- a/backend/clouddm-utils/cg-detectrule/src/main/java/com/clougence/detectrule/lang/reflect/ReflectHelper.java
+++ b/backend/clouddm-utils/cg-detectrule/src/main/java/com/clougence/detectrule/lang/reflect/ReflectHelper.java
@@ -23,6 +23,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.clougence.detectrule.lang.CollectionAccess;
 import com.clougence.detectrule.lang.EnumAccess;
@@ -37,7 +38,7 @@ import com.clougence.utils.StringUtils;
 //
 public final class ReflectHelper {
 
-    private static Map<TypeType, Type> atomicTypeMap = new HashMap<>();
+    private static Map<TypeType, Type> atomicTypeMap = new ConcurrentHashMap<>();
     private static Set<String>         ignoreFields  = new HashSet<>();
 
     public static void addIgnoreField(String fieldName) {


### PR DESCRIPTION
## Summary

Fix the `ConcurrentModificationException` raised while masking query results in parallel. The atomic type cache in `ReflectHelper` now uses a concurrent map so concurrent `computeIfAbsent` calls are safe.

## Related Issues

Closes #235

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Replace the non-thread-safe `HashMap` used by the atomic type cache with `ConcurrentHashMap`.
- Keep the existing cache behavior and rule execution flow unchanged.

## Test Plan

- [ ] Not tested (explain why below)
- [x] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [ ] Backend build
- [ ] Manual verification

Details:

```text
cd backend
./gradlew :cg-detectrule:test :plus-sec-rules:test
BUILD SUCCESSFUL
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [x] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
