### PR TITLE
Fix/result cell copy

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -299,11 +299,11 @@ export default {
             const rect = ele.getBoundingClientRect();
             let calcWidth = rect.width;
 
-            if (rect.width >= 60) {
+            if (rect.width >= 180) {
               calcWidth += leftWidth;
             }
-            if (calcWidth < 60) {
-              calcWidth = 60;
+            if (calcWidth < 180) {
+              calcWidth = 180;
               needMouseUp = true;
             }
 

--- a/frontend/src/views/sql/components/DataSourceTree.vue
+++ b/frontend/src/views/sql/components/DataSourceTree.vue
@@ -13,6 +13,7 @@ import { NODE_TYPE, DS_RIGHT_CLICK_MENU_ITEM } from '@/utils';
 import utilMixin from '@/mixins/utilMixin';
 import { clearAllPending } from '@/services/http/cancelRequest';
 import AddDataSource from '@/views/dataSource/AddDataSource';
+import TreeNodeLabel from '@/views/sql/components/TreeNodeLabel';
 
 const DATASOURCE_EXPANDED_KEYS_KEY = 'clouddm_datasource_expanded_keys';
 const SEARCH_PANEL_EXPANDED_WIDTH = 280;
@@ -689,14 +690,16 @@ export default {
           ) : (
             <CustomIcon type={icon} />
           )}
-          <div
-            style={{
+          <TreeNodeLabel
+            text={title}
+            html={this.highlight(title, this.searchKey)}
+            labelStyle={{
               marginLeft: '3px',
               marginRight: `${nodeType === 'INSTANCE' && !node.connected ? '20px' : '0'}`,
               color: `${node.isNew ? 'green' : this.isDark ? '#fff' : '#000'}`,
               fontWeight: `${node.isNew ? 'bold' : 'default'}`
             }}
-            innerHTML={this.highlight(title, this.searchKey)}></div>
+          />
           {nodeType === 'INSTANCE' && !node.connected && (
             <Tooltip placement='right' content={node.connectedMsg} transfer style={{ position: 'absolute', right: '3px' }}>
               <cc-svg-icon
@@ -709,7 +712,11 @@ export default {
               />
             </Tooltip>
           )}
-          {children && children.length > 0 && <div style='font-weight: bold;color: #bbb;'>[{children.length}]</div>}
+          {children && children.length > 0 && (
+            <div class='node-badge' style='font-weight: bold;color: #bbb;'>
+              [{children.length}]
+            </div>
+          )}
         </div>
       );
     },
@@ -1589,10 +1596,21 @@ export default {
     padding: 2px 0 0 4px;
     flex: 1;
     min-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
+    :deep(.ctree-tree__wrapper),
+    :deep(.vtree-tree__wrapper) {
+      flex: 1;
+      min-height: 0;
+    }
 
     :deep(.node) {
       display: flex;
       align-items: center;
+      min-width: 0;
+      overflow: hidden;
     }
   }
 

--- a/frontend/src/views/sql/components/Operators.vue
+++ b/frontend/src/views/sql/components/Operators.vue
@@ -84,10 +84,10 @@
               </template>
             </Dropdown>
           </Button>
-          <Button size="small" v-if="isSupportTx && !tab.autoCommit" :disabled="isRunning" @click="handleCommit">
+          <Button size="small" v-if="showTxActions" @click="handleCommit">
             {{ $t('ti-jiao') }}
           </Button>
-          <Button size="small" v-if="isSupportTx && !tab.autoCommit" :disabled="isRunning" @click="handleRollback">
+          <Button size="small" v-if="showTxActions" @click="handleRollback">
             {{ $t('hui-gun') }}
           </Button>
           <Button size="small" v-if="isSupportReadOnly" class="readonly-operator-btn" @click="handleReadOnlyClick">
@@ -139,6 +139,9 @@ export default {
     },
     isSupportTx() {
       return this.tab.support.autoCommit.conf !== 'No';
+    },
+    showTxActions() {
+      return this.isSupportTx && !this.tab.autoCommit && !this.isRunning;
     },
     isSupportReadOnly() {
       return this.tab.support.readOnly.conf !== 'No';

--- a/frontend/src/views/sql/components/Result.vue
+++ b/frontend/src/views/sql/components/Result.vue
@@ -29,7 +29,7 @@
                   type="icon-v2-close2"
                   hoverStyle
                   customStyle="radius-hover"
-                  @click.native="handleCloseResultTab('current', res.resultId)"
+                  @click.native.stop="handleCloseResultTab('current', res.resultId)"
                 />
               </div>
             </template>
@@ -44,7 +44,11 @@
                       <CustomIcon type="icon-v2-Table" />
                       <div style="margin-left: 5px; white-space: nowrap">{{ `${$t('jie-guo')}${res.showIndex}` }}</div>
                       <div class="dropdown-item-close">
-                        <CustomIcon type="icon-v2-close2" customStyle="icon-v2-hover" @click.native="handleCloseResultTab('current', res.resultId)" />
+                        <CustomIcon
+                          type="icon-v2-close2"
+                          customStyle="icon-v2-hover"
+                          @click.native.stop="handleCloseResultTab('current', res.resultId)"
+                        />
                       </div>
                     </div>
                   </a-menu-item>
@@ -89,7 +93,7 @@
         </div>
       </div>
       <div
-        v-if="!['message', 'async'].includes(tab.result.active)"
+        v-if="!['message', 'async'].includes(tab.result.active) && selectedTab.resultId"
         class="result-content-wrapper"
         style="display: flex; flex-direction: column; flex: 1; min-height: 0"
       >
@@ -197,10 +201,10 @@
               <template v-if="column.dataIndex !== 'seq'">
                 <div class="vxe-input-tpl" @dblclick.stop="handleCellDetail(record, column, index)">
                   <span v-if="record[column.dataIndex] === null" style="color: #ccc; font-style: italic">NULL</span>
-                  <pre v-else style="overflow: hidden; margin: 0" v-html="record[column.dataIndex]"></pre>
+                  <pre v-else style="overflow: hidden; margin: 0">{{ record[column.dataIndex] }}</pre>
                   <div v-if="!getCellComplete(column, index)" class="cell-incomplete-badge"></div>
                   <div class="op">
-                    <div @click.stop="handleCellCopy(record[column.dataIndex])" style="margin-right: 3px">
+                    <div @click.stop="handleCellCopy(record, column, index)" style="margin-right: 3px">
                       <cc-iconfont name="copy" :size="12" />
                     </div>
                     <div @click.stop="handleCellDetail(record, column, index)">
@@ -513,18 +517,11 @@ export default {
       ];
     },
     selectedTab() {
-      if (!['message'].includes(this.tab.result.active)) {
-        let tab = {};
-        for (let i = 0; i < this.tab.result.list.length; i++) {
-          if (this.tab.result.list[i].resultId === this.tab.result.active) {
-            tab = this.tab.result.list[i];
-            break;
-          }
-        }
-        return tab;
-      } else {
+      if (['message', 'async'].includes(this.tab.result.active)) {
         return {};
       }
+      const matched = this.tab.result.list.find((item) => item.resultId === this.tab.result.active);
+      return matched || {};
     },
     antdColumns() {
       if (!this.selectedTab || !this.selectedTab.columnListSeq) {
@@ -598,6 +595,11 @@ export default {
         for (let i = 0; i < resultIds.length; i++) {
           this.paginatedLoading[resultIds[i]] = false;
         }
+      }
+    },
+    'tab.result.list.length'(length) {
+      if (!length && !['message', 'async'].includes(this.tab.result.active)) {
+        this.tab.result.active = 'message';
       }
     },
     'tab.result.active'(activeKey) {
@@ -735,6 +737,9 @@ export default {
       appLogger.debug(type, key);
       if (type === 'current') {
         const deleteIndex = this.tab.result.list.findIndex((tab) => tab.resultId === key);
+        if (deleteIndex < 0) {
+          return;
+        }
         const closingTab = this.tab.result.list[deleteIndex];
         if (closingTab) {
           this.callCloseResultWindow(closingTab);
@@ -788,6 +793,13 @@ export default {
       });
     },
     handleResultTabChange(activeKey) {
+      if (activeKey !== 'message' && activeKey !== 'async') {
+        const exists = this.tab.result.list.some((item) => item.resultId === activeKey);
+        if (!exists) {
+          this.tab.result.active = 'message';
+          activeKey = 'message';
+        }
+      }
       this.tab.result.active = activeKey;
 
       // process message table scroll position
@@ -930,138 +942,159 @@ export default {
         minWidth: 100
       });
     },
-    handleCellCopy(value) {
-      if (value !== null && value !== undefined) {
-        if (XEClipboard.copy(value)) {
-          this.$message.success(this.$t('fu-zhi-cheng-gong'));
+    async handleCellCopy(record, column, rowIndex) {
+      const value = record[column.dataIndex];
+      if (value === null || value === undefined) {
+        return;
+      }
+
+      let text = String(value);
+      const cellMeta = this.getCellValueMeta(column, rowIndex);
+      if (cellMeta && !cellMeta.complete && !cellMeta.error && !cellMeta.mask && cellMeta.moreSize > 0) {
+        try {
+          text = await this.fetchFullCellText(cellMeta, text);
+        } catch (error) {
+          appLogger.error('复制单元格完整内容失败:', error);
+          this.$Message.error(this.$t('fu-zhi-shi-bai'));
+          return;
         }
       }
+
+      if (XEClipboard.copy(text)) {
+        this.$message.success(this.$t('fu-zhi-cheng-gong'));
+      }
+    },
+    getCellRowNumber(rowIndex) {
+      const receiveMode = this.selectedTab.receiveMode || 'PAGE_FULL';
+      if (receiveMode === 'PAGINATED') {
+        const pageSize = this.selectedTab.size || 30;
+        return ((this.selectedTab.page || 1) - 1) * pageSize + rowIndex;
+      }
+      if (receiveMode === 'STREAM') {
+        return rowIndex;
+      }
+      const pageSize = this.selectedTab.size || 50;
+      return ((this.selectedTab.page || 1) - 1) * pageSize + rowIndex;
+    },
+    getCellValueMeta(column, rowIndex) {
+      const colIndex = this.selectedTab.columnList?.findIndex((col) => col === column.dataIndex || col === column.property) ?? -1;
+      if (colIndex < 0) {
+        return null;
+      }
+
+      const meta = {
+        resultId: this.selectedTab.resultId,
+        rowNumber: this.getCellRowNumber(rowIndex),
+        colIndex,
+        complete: true,
+        moreSize: 0,
+        totalSize: 0,
+        error: false,
+        mask: false
+      };
+
+      try {
+        const receiveMode = this.selectedTab.receiveMode || 'PAGE_FULL';
+        let cellValue = null;
+
+        if (receiveMode === 'PAGINATED') {
+          const currentPage = this.selectedTab.page || 1;
+          const rowSetCache = this.selectedTab.rowSetCache;
+          if (rowSetCache && rowSetCache[currentPage] && rowSetCache[currentPage][rowIndex]) {
+            const rowItem = rowSetCache[currentPage][rowIndex];
+            const rowData = rowItem.data || rowItem.row;
+            if (rowData && Array.isArray(rowData) && rowData[colIndex]) {
+              cellValue = rowData[colIndex];
+            }
+          }
+        } else if (receiveMode === 'STREAM') {
+          const rowSetStream = this.selectedTab.rowSetStream;
+          const streamData = this.selectedTab.streamData || [];
+          const displayCount = 30;
+          const startIndex = streamData.length > displayCount ? streamData.length - displayCount : 0;
+          const actualIndex = startIndex + rowIndex;
+          if (rowSetStream && rowSetStream[actualIndex]) {
+            const rowItem = rowSetStream[actualIndex];
+            const rowData = rowItem.data || rowItem.row;
+            if (rowData && Array.isArray(rowData) && rowData[colIndex]) {
+              cellValue = rowData[colIndex];
+            }
+          }
+        } else if (this.selectedTab.data && this.selectedTab.data[meta.rowNumber]) {
+          const rowItem = this.selectedTab.data[meta.rowNumber];
+          const rawData = Array.isArray(rowItem) ? rowItem : rowItem.data || rowItem.row;
+          if (rawData && Array.isArray(rawData) && rawData[colIndex]) {
+            cellValue = rawData[colIndex];
+          }
+        }
+
+        if (cellValue) {
+          meta.complete = cellValue.complete !== undefined ? cellValue.complete : true;
+          meta.moreSize = cellValue.moreSize || 0;
+          meta.totalSize = cellValue.totalSize || 0;
+          meta.error = cellValue.error || false;
+          meta.mask = cellValue.mask || false;
+        }
+      } catch (err) {
+        appLogger.debug('获取单元格元数据失败:', err);
+      }
+
+      return meta;
+    },
+    async fetchFullCellText(cellMeta, initialValue) {
+      let content = initialValue || '';
+      let moreSize = cellMeta.moreSize || 0;
+      const fetchSize = 128 * 1024;
+      let guard = 0;
+
+      while (moreSize > 0 && guard < 100) {
+        guard += 1;
+        const res = await this.$services.dmQueryFetchResultData({
+          data: {
+            resultId: cellMeta.resultId,
+            rowNumber: cellMeta.rowNumber,
+            colNumber: cellMeta.colIndex,
+            offset: content.length,
+            fetchSize
+          }
+        });
+
+        if (!res.success || !res.data) {
+          throw new Error(res.message || 'fetch failed');
+        }
+
+        const dataValue = res.data.value || res.data;
+        if (dataValue.error) {
+          throw new Error('fetch error');
+        }
+
+        const chunk = dataValue.value || '';
+        if (!chunk && (dataValue.moreSize || 0) > 0) {
+          throw new Error('empty chunk');
+        }
+
+        content += chunk;
+        moreSize = dataValue.moreSize || 0;
+        if (dataValue.complete) {
+          break;
+        }
+      }
+
+      return content;
     },
     // Get the cell's complete flag to decide whether to show the corner marker.
     getCellComplete(column, rowIndex) {
-      try {
-        const colIndex = this.selectedTab.columnList?.findIndex((col) => col === column.dataIndex || col === column.property) ?? -1;
-        if (colIndex < 0) return true;
-
-        const receiveMode = this.selectedTab.receiveMode || 'PAGE_FULL';
-
-        if (receiveMode === 'PAGINATED') {
-          const currentPage = this.selectedTab.page || 1;
-          const rowSetCache = this.selectedTab.rowSetCache;
-
-          if (rowSetCache && rowSetCache[currentPage] && rowSetCache[currentPage][rowIndex]) {
-            const rowItem = rowSetCache[currentPage][rowIndex];
-            const rowData = rowItem.data || rowItem.row;
-
-            if (rowData && Array.isArray(rowData) && rowData[colIndex]) {
-              return rowData[colIndex].complete !== undefined ? rowData[colIndex].complete : true;
-            }
-          }
-        } else if (receiveMode === 'STREAM') {
-          const rowSetStream = this.selectedTab.rowSetStream;
-          const streamData = this.selectedTab.streamData || [];
-
-          const displayCount = 30;
-          const startIndex = streamData.length > displayCount ? streamData.length - displayCount : 0;
-          const actualIndex = startIndex + rowIndex;
-
-          if (rowSetStream && rowSetStream[actualIndex]) {
-            const rowItem = rowSetStream[actualIndex];
-            const rowData = rowItem.data || rowItem.row;
-
-            if (rowData && Array.isArray(rowData) && rowData[colIndex]) {
-              return rowData[colIndex].complete !== undefined ? rowData[colIndex].complete : true;
-            }
-          }
-        } else {
-          if (this.selectedTab.data && this.selectedTab.data[rowIndex]) {
-            const rowData = this.selectedTab.data[rowIndex];
-            if (Array.isArray(rowData) && rowData[colIndex]) {
-              return rowData[colIndex].complete !== undefined ? rowData[colIndex].complete : true;
-            }
-          }
-        }
-      } catch (err) {
-        appLogger.debug('获取单元格 complete 字段失败:', err);
+      const cellMeta = this.getCellValueMeta(column, rowIndex);
+      if (!cellMeta) {
+        return true;
       }
-      return true;
+      return cellMeta.complete;
     },
     handleCellDetail(record, column, rowIndex) {
-      const colIndex = this.selectedTab.columnList?.findIndex((col) => col === column.dataIndex || col === column.property) ?? -1;
-
-      // Calculate the actual row number, accounting for pagination.
-      let rowNumber = rowIndex;
-      if (this.selectedTab.receiveMode === 'PAGINATED') {
-        const pageSize = 30;
-        rowNumber = (this.selectedTab.page - 1) * pageSize + rowIndex;
-      } else if (this.selectedTab.receiveMode === 'STREAM') {
-        rowNumber = rowIndex;
-      } else {
-        const pageSize = 50;
-        rowNumber = (this.selectedTab.page - 1) * pageSize + rowIndex;
-      }
-
+      const cellMeta = this.getCellValueMeta(column, rowIndex);
+      const colIndex = cellMeta ? cellMeta.colIndex : -1;
+      const rowNumber = cellMeta ? cellMeta.rowNumber : rowIndex;
       const cellValue = record[column.dataIndex || column.property] || '';
-
-      let moreSize = 0;
-      let totalSize = 0;
-      let complete = true;
-      let error = false;
-      let mask = false;
-      try {
-        const receiveMode = this.selectedTab.receiveMode || 'PAGE_FULL';
-
-        if (receiveMode === 'PAGINATED') {
-          const currentPage = this.selectedTab.page || 1;
-          const rowSetCache = this.selectedTab.rowSetCache;
-
-          if (rowSetCache && rowSetCache[currentPage] && rowSetCache[currentPage][rowIndex]) {
-            const rowItem = rowSetCache[currentPage][rowIndex];
-            const rowData = rowItem.data || rowItem.row;
-
-            if (rowData && Array.isArray(rowData) && rowData[colIndex]) {
-              moreSize = rowData[colIndex].moreSize || 0;
-              totalSize = rowData[colIndex].totalSize || 0;
-              complete = rowData[colIndex].complete !== undefined ? rowData[colIndex].complete : true;
-              error = rowData[colIndex].error || false;
-              mask = rowData[colIndex].mask || false;
-            }
-          }
-        } else if (receiveMode === 'STREAM') {
-          const rowSetStream = this.selectedTab.rowSetStream;
-          const streamData = this.selectedTab.streamData || [];
-
-          const displayCount = 30;
-          const startIndex = streamData.length > displayCount ? streamData.length - displayCount : 0;
-          const actualIndex = startIndex + rowIndex;
-
-          if (rowSetStream && rowSetStream[actualIndex]) {
-            const rowItem = rowSetStream[actualIndex];
-            const rowData = rowItem.data || rowItem.row;
-
-            if (rowData && Array.isArray(rowData) && rowData[colIndex]) {
-              moreSize = rowData[colIndex].moreSize || 0;
-              totalSize = rowData[colIndex].totalSize || 0;
-              complete = rowData[colIndex].complete !== undefined ? rowData[colIndex].complete : true;
-              error = rowData[colIndex].error || false;
-              mask = rowData[colIndex].mask || false;
-            }
-          }
-        } else {
-          if (this.selectedTab.data && this.selectedTab.data[rowIndex]) {
-            const rowData = this.selectedTab.data[rowIndex];
-            if (Array.isArray(rowData) && rowData[colIndex]) {
-              moreSize = rowData[colIndex].moreSize || 0;
-              totalSize = rowData[colIndex].totalSize || 0;
-              complete = rowData[colIndex].complete !== undefined ? rowData[colIndex].complete : true;
-              error = rowData[colIndex].error || false;
-              mask = rowData[colIndex].mask || false;
-            }
-          }
-        }
-      } catch (err) {
-        appLogger.debug('获取单元格原始数据失败:', err);
-      }
 
       this.$bus.emit('showCellDetailModal', {
         row: record,
@@ -1070,11 +1103,11 @@ export default {
         rowNumber,
         colNumber: colIndex,
         cellValue,
-        moreSize,
-        totalSize,
-        complete,
-        error,
-        mask
+        moreSize: cellMeta ? cellMeta.moreSize : 0,
+        totalSize: cellMeta ? cellMeta.totalSize : 0,
+        complete: cellMeta ? cellMeta.complete : true,
+        error: cellMeta ? cellMeta.error : false,
+        mask: cellMeta ? cellMeta.mask : false
       });
     },
     generateRowInsert(row) {
@@ -1790,7 +1823,6 @@ export default {
       }
 
       :deep(.ant-table-thead > tr > th .header-cell-content) {
-        position: relative;
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -1806,10 +1838,10 @@ export default {
 
         .resize-handle {
           position: absolute;
-          right: 0;
+          right: -2px;
           top: 0;
           bottom: 0;
-          width: 4px;
+          width: 5px;
           cursor: col-resize;
           z-index: 10;
           background: transparent;
@@ -1817,7 +1849,59 @@ export default {
       }
 
       :deep(.ant-table-tbody > tr > td) {
-        padding: 2px 8px;
+        padding: 0;
+        position: relative;
+      }
+
+      :deep(.ant-table-tbody .ant-table-cell) {
+        padding: 0 !important;
+      }
+
+      :deep(.ant-table-tbody .ant-table-cell:hover) .vxe-input-tpl .op {
+        display: flex;
+        align-items: center;
+      }
+
+      .vxe-input-tpl {
+        position: relative;
+        display: flex;
+        align-items: center;
+        width: 100%;
+        min-height: 24px;
+        height: auto;
+        padding: 3px 8px;
+        box-sizing: border-box;
+
+        pre {
+          flex: 1;
+          min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .op {
+          display: none;
+          position: absolute;
+          right: 4px;
+          top: 50%;
+          transform: translateY(-50%);
+          background: rgba(255, 255, 255, 0.95);
+          padding: 2px 4px;
+          border-radius: 3px;
+          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+          div {
+            display: inline-block;
+            cursor: pointer;
+            padding: 2px;
+            transition: all 0.2s;
+
+            &:hover {
+              opacity: 0.7;
+            }
+          }
+        }
       }
 
       // Remove blank lines.
@@ -2246,6 +2330,6 @@ export default {
   padding: 0 !important;
 }
 :deep(.ant-table-tbody .ant-table-cell) {
-  padding: 3px !important;
+  padding: 0 !important;
 }
 </style>

--- a/frontend/src/views/sql/components/TableList.vue
+++ b/frontend/src/views/sql/components/TableList.vue
@@ -60,29 +60,30 @@
         :class="!['TABLE', 'VIEW', 'PROC', 'FUNC'].includes(currentTab.leafType) ? 'no-indent' : ''"
       >
         <loading :active="tableListLoading" :is-full-page="false"></loading>
-        <v-tree
-          :emptyText="$t('dian-ji-jia-zai-shu-ju')"
-          class="table-list-tree"
-          ref="tableTree"
-          key-field="key"
-          :load="handleExpandLoadNode"
-          :render="renderNode"
-          :nodeIndent="20"
-          :renderNodeAmount="200"
-          @click="handleVTreeClick"
-          @node-right-click="handleNodeRightClick"
-        >
-          <template #empty>
-            <div v-if="!tableListLoading">
-              <span>{{ $t('zan-wu-shu-ju') }}</span>
-              <br />
-              <a-button type="text" ghost @click="handleRefreshTree">
-                <CustomIcon type="icon-v2-Refresh" />
-                <span style="padding-left: 5px">{{ $t('dian-ji-jia-zai-shu-ju') }}</span>
-              </a-button>
-            </div>
-          </template>
-        </v-tree>
+        <div class="table-list-tree">
+          <v-tree
+            :emptyText="$t('dian-ji-jia-zai-shu-ju')"
+            ref="tableTree"
+            key-field="key"
+            :load="handleExpandLoadNode"
+            :render="renderNode"
+            :nodeIndent="20"
+            :renderNodeAmount="200"
+            @click="handleVTreeClick"
+            @node-right-click="handleNodeRightClick"
+          >
+            <template #empty>
+              <div v-if="!tableListLoading">
+                <span>{{ $t('zan-wu-shu-ju') }}</span>
+                <br />
+                <a-button type="text" ghost @click="handleRefreshTree">
+                  <CustomIcon type="icon-v2-Refresh" />
+                  <span style="padding-left: 5px">{{ $t('dian-ji-jia-zai-shu-ju') }}</span>
+                </a-button>
+              </div>
+            </template>
+          </v-tree>
+        </div>
       </div>
       <div class="object-list-pagination">
         <span class="object-list-pagination__total">{{ $t('gong') }}{{ filteredObjectCount }}{{ $t('tiao') }}</span>
@@ -1015,6 +1016,7 @@ import i18n from '@/i18n';
 import { nanoid } from 'nanoid';
 import ContextMenu from '@imengyu/vue3-context-menu';
 import { resolveBrowserMenuLabel } from '@/utils/browserMenuI18n';
+import TreeNodeLabel from '@/views/sql/components/TreeNodeLabel';
 
 const BG_COLOR = {
   Insert: 'rgb(236, 255, 220)',
@@ -2470,25 +2472,31 @@ export default {
       return rootNode;
     },
     renderNode(node) {
-      const { title, icon, tips, children, nodeType, objName, objAttr, isLeaf } = node;
+      const { title, icon, tips, children, nodeType, objName, objAttr } = node;
+      const labelText = objName || title;
+      let tooltipText = labelText;
+      if (tips) {
+        tooltipText = `${tooltipText} ${tips}`;
+      }
+      if (objAttr && objAttr.rdb_tips) {
+        tooltipText = `${tooltipText} ${objAttr.rdb_tips}`;
+      }
 
       return (
-        <div class={['node']} style={isLeaf ? 'position: relative; left: -20px;' : ''} key={title}>
+        <div class='node' key={title}>
           {icon && <cc-svg-icon name={icon} />}
-          {objAttr && objAttr.rdb_disabled === 'true' && (
-            <Tooltip content={'禁用'} transfer>
-              <Icon type={'md-close-circle'} color='red' />
-            </Tooltip>
+          {objAttr && objAttr.rdb_disabled === 'true' && <Icon type={'md-close-circle'} color='red' title='禁用' />}
+          {objAttr && objAttr.rdb_invalid === 'true' && <Icon type={'md-close-circle'} color='red' title='编译未通过' />}
+          <TreeNodeLabel
+            text={tooltipText}
+            html={this.highlight(labelText, this.currentTab[this.currentTab.leafType].searchKey)}
+            labelStyle={{ marginLeft: '3px' }}
+          />
+          {children && ['GROUP', 'RDB_PARAM'].includes(nodeType) && (
+            <div class='node-badge' style='font-weight: bold;color: #bbb;'>
+              [{children.length}]
+            </div>
           )}
-          {objAttr && objAttr.rdb_invalid === 'true' && (
-            <Tooltip content={'编译未通过'} transfer>
-              <Icon type={'md-close-circle'} color='red' />
-            </Tooltip>
-          )}
-          <div style={{ marginLeft: '3px' }} innerHTML={this.highlight(objName || title, this.currentTab[this.currentTab.leafType].searchKey)}></div>
-          {children && ['GROUP', 'RDB_PARAM'].includes(nodeType) && <div style='font-weight: bold;color: #bbb;'>[{children.length}]</div>}
-          {tips && <div style={{ marginLeft: '3px', color: '#ccc' }}>{tips}</div>}
-          {objAttr && objAttr.rdb_tips && <div style='color: #bbb;'>&nbsp;{objAttr.rdb_tips}</div>}
         </div>
       );
     },
@@ -4162,12 +4170,36 @@ export default {
 }
 
 .table-list-tree {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
   .ivu-btn-text:focus {
     box-shadow: none;
   }
 
   .ivu-btn:focus {
     box-shadow: none;
+  }
+
+  :deep(.vtree-tree__wrapper),
+  :deep(.ctree-tree__wrapper) {
+    flex: 1;
+    min-height: 0;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  :deep(.node) {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    max-width: 100%;
+    width: 100%;
+    overflow: hidden;
   }
 }
 
@@ -4221,6 +4253,9 @@ export default {
 :deep(.node) {
   display: flex;
   align-items: center;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 :deep(.no-indent) {

--- a/frontend/src/views/sql/components/TreeNodeLabel.vue
+++ b/frontend/src/views/sql/components/TreeNodeLabel.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="tree-node-label-wrap">
+    <Tooltip :content="text" placement="top" transfer :disabled="!truncated">
+      <div
+        ref="labelRef"
+        class="tree-node-label"
+        :style="labelStyle"
+        v-html="html || text"
+        @mouseenter="checkTruncated"
+        @mouseleave="truncated = false"
+      ></div>
+    </Tooltip>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'TreeNodeLabel',
+  props: {
+    text: {
+      type: String,
+      required: true
+    },
+    html: {
+      type: String,
+      default: ''
+    },
+    labelStyle: {
+      type: Object,
+      default: () => ({})
+    }
+  },
+  data() {
+    return {
+      truncated: false
+    };
+  },
+  methods: {
+    checkTruncated() {
+      const el = this.$refs.labelRef;
+      if (!el) {
+        return;
+      }
+      this.truncated = el.scrollWidth > el.clientWidth;
+    }
+  }
+};
+</script>
+
+<style scoped lang="less">
+.tree-node-label-wrap {
+  flex: 1 1 0%;
+  width: 0;
+  min-width: 0;
+  overflow: hidden;
+
+  :deep(.ivu-tooltip) {
+    display: block !important;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  :deep(.ivu-tooltip-rel) {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
+  }
+}
+
+.tree-node-label {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/frontend/src/views/sql/style/index.less
+++ b/frontend/src/views/sql/style/index.less
@@ -128,7 +128,7 @@
     }
 
     .table-open {
-      width: 204px;
+      width: 260px;
     }
 
     .table-close {
@@ -186,7 +186,9 @@
 
             .table-list-container {
               position: relative;
-              width: 200px;
+              width: 260px;
+              min-width: 180px;
+              overflow: hidden;
               background: var(--bg-secondary);
               border-right: 1px solid var(--border-primary);
               display: flex;
@@ -207,9 +209,24 @@
 
                 .table-query-item-container {
                   padding-left: 4px;
-                  overflow: auto;
+                  overflow: hidden;
                   user-select: none;
                   flex: 1;
+                  min-height: 0;
+                  display: flex;
+                  flex-direction: column;
+
+                  .table-list-tree {
+                    flex: 1;
+                    min-height: 0;
+                    overflow: hidden;
+                    height: 100%;
+
+                    .vtree-tree__wrapper,
+                    .ctree-tree__wrapper {
+                      height: 100%;
+                    }
+                  }
 
                   .no-data-tip {
                     text-align: center;

--- a/frontend/src/views/sql/style/workspace-ui.less
+++ b/frontend/src/views/sql/style/workspace-ui.less
@@ -67,6 +67,163 @@
     }
   }
 
+  // Tree sidebar: constrain row width to panel, ellipsis labels, overlay scrollbar
+  .datasource-tree,
+  .table-list-tree {
+    .ctree-tree__scroll-area,
+    .vtree-tree__scroll-area {
+      display: block;
+      overflow-x: hidden !important;
+      overflow-y: auto;
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+
+      &::-webkit-scrollbar:horizontal {
+        display: none;
+        height: 0;
+      }
+
+      &:hover {
+        scrollbar-color: rgba(50, 50, 50, 0.35) transparent;
+      }
+
+      &::-webkit-scrollbar {
+        width: 6px;
+        height: 6px;
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background-color: transparent;
+        border-radius: 3px;
+      }
+
+      &:hover::-webkit-scrollbar-thumb {
+        background-color: rgba(50, 50, 50, 0.35);
+      }
+
+      &::-webkit-scrollbar-track {
+        background: transparent;
+      }
+    }
+
+    .ctree-tree__block-area,
+    .vtree-tree__block-area {
+      width: 100%;
+      max-width: 100%;
+      box-sizing: border-box;
+      flex: none;
+    }
+
+    .ctree-tree-node__indent-wrapper,
+    .vtree-tree-node__indent-wrapper {
+      width: 100%;
+      max-width: 100%;
+      box-sizing: border-box;
+    }
+
+    .ctree-tree-node__wrapper,
+    .vtree-tree-node__wrapper {
+      flex: 1;
+      min-width: 0;
+      max-width: 100%;
+      overflow: hidden;
+    }
+
+    .ctree-tree-node__node-body,
+    .vtree-tree-node__node-body {
+      flex: 1 1 0%;
+      min-width: 0;
+      max-width: 100%;
+      overflow: hidden;
+    }
+
+    .ctree-tree-node__title,
+    .vtree-tree-node__title {
+      flex: 1 1 0%;
+      min-width: 0;
+      max-width: 100%;
+      overflow: hidden;
+    }
+
+    .node {
+      display: flex;
+      align-items: center;
+      min-width: 0;
+      max-width: 100%;
+      width: 100%;
+      overflow: hidden;
+      box-sizing: border-box;
+
+      > .tree-node-label-wrap {
+        flex: 1 1 0%;
+        width: 0;
+        min-width: 0;
+        overflow: hidden;
+      }
+
+      > *:not(.tree-node-label-wrap) {
+        flex-shrink: 0;
+      }
+
+      .node-badge {
+        flex-shrink: 0;
+      }
+    }
+
+    .tree-node-label {
+      display: block;
+      width: 100%;
+      flex: 1 1 0%;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  .table-query-item-container {
+    flex: 1;
+    min-height: 0;
+    min-width: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
+    .table-list-tree {
+      flex: 1;
+      min-height: 0;
+      min-width: 0;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+
+      .vtree-tree__wrapper,
+      .ctree-tree__wrapper {
+        flex: 1;
+        min-height: 0;
+        min-width: 0;
+        height: 100%;
+        overflow: hidden;
+      }
+    }
+  }
+
+  [data-theme='dark'] & {
+    .datasource-tree,
+    .table-list-tree {
+      .ctree-tree__scroll-area,
+      .vtree-tree__scroll-area {
+        &:hover {
+          scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
+        }
+
+        &:hover::-webkit-scrollbar-thumb {
+          background-color: rgba(255, 255, 255, 0.25);
+        }
+      }
+    }
+  }
+
   // Data source panel ─
   .data-source-container {
     background: var(--bg-secondary) !important;
@@ -112,6 +269,13 @@
   .table-list-container {
     background: var(--bg-secondary) !important;
     border-right: 1px solid var(--border-primary) !important;
+    min-width: 180px;
+  }
+
+  .table-list-content {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
   }
 
   .search-header {


### PR DESCRIPTION
## Summary

Improve SQL workspace frontend UX and fix result-cell copy issues: port tree/empty-tab polish from `feat/data_edit` (frontend only), and make result cells easier to interact with and copy correctly.

## Related Issues

None

## Type of Change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Port SQL tree sidebar UX (ellipsis labels, panel width, scrollbar, tx button visibility)
- Harden empty/invalid result tab switching and close behavior
- Align column resize handle to the column border
- Show cell copy/view actions on full-cell hover
- Fetch full truncated cell content before copy; render cell text instead of `v-html`

## Test Plan

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [x] Frontend lint / build
- [ ] Backend build
- [ ] Manual verification

Details:

```text
cd package && ./all_build.sh web
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [ ] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.