### PR TITLE
fix(sql): show Monaco SQL diagnostic messages

### DIFF
--- a/frontend/src/views/sql/components/SqlViewer.vue
+++ b/frontend/src/views/sql/components/SqlViewer.vue
@@ -30,11 +30,11 @@
       @change="handleEditorChange"
     />
     <div class="editor-resize" />
-    <div :class="`message ${tab.message.type}`" v-if="tab.message.text && tab.message.show && tab.connected">
+    <div :class="`query-message ${tab.message.type}`" v-if="tab.message.text && tab.message.show && tab.connected">
       <div v-html="tab.message.text"></div>
       <CustomIcon type="icon-v2-close2" @click="handleCloseError" hoverStyle />
     </div>
-    <div class="message Error" v-if="!tab.connected && tab.msgContent">
+    <div class="query-message Error" v-if="!tab.connected && tab.msgContent">
       {{ tab.msgContent }}
       <Button type="text" size="small" @click="handleClickDsStatusIcon">
         {{ $t('zhong-xin-lian-jie') }}
@@ -958,7 +958,7 @@ export default {
     background: rgba(0, 0, 0, 0);
   }
 
-  .message {
+  .query-message {
     position: absolute;
     bottom: 0;
     width: 100%;


### PR DESCRIPTION
## Summary

Fix SQL editor diagnostic messages being clipped and invisible in the Monaco problem panel.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Rename the SQL query status banner class from `.message` to `.query-message`.
- Keep query status banner styles from overriding Monaco’s internal `.message` diagnostic element.
- Preserve the existing query status and disconnected-state banner behavior.

| Before | After |
| --- | --- |
| <img width="464" height="247" alt="Before：SQL editor error message is obscured" src="https://github.com/user-attachments/assets/e01dc7ac-5e08-489a-a71d-1122ceb13100" /> | <img width="332" height="146" alt="After：SQL editor displays the error message correctly" src="https://github.com/user-attachments/assets/1f1ca40a-8db1-43d6-a0bb-947887bd6f38" /> |

## Test Plan

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [x] Frontend lint / build
- [ ] Backend build
- [x] Manual verification

Details:

```text
npm run lint -- --no-fix
git diff --check

Reproduced the SQL editor issue in the browser with an invalid statement. The Monaco diagnostic text was clipped because the surrounding SqlViewer .message styles were applied to Monaco’s internal diagnostic node.
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [x] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
