### PR TITLE
fix(clickhouse): fix fetchSize error and add JSON/Map/Tuple/Dynamic type support

### DIFF
--- a/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/execute/ChColReader.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/execute/ChColReader.java
@@ -27,6 +27,8 @@ import com.clougence.utils.StringUtils;
  **/
 public class ChColReader extends AbstractColReader {
 
+    private static final ValueFetcher TUPLE_VALUE_FETCHER = new ChTupleValueFetcher();
+
     @Override
     public ValueFetcher readColumn(String col, ColMetaData colMetaData) {
         String colType = StringUtils.defaultString(colMetaData.getColumnType(), "").toLowerCase();
@@ -39,6 +41,16 @@ public class ChColReader extends AbstractColReader {
             colType = "decimal";
         } else if (colType.startsWith("datetime64")) {
             colType = "datetime64";
+        } else if (colType.startsWith("map")) {
+            colType = "map";
+        } else if (colType.startsWith("array")) {
+            colType = "array";
+        } else if (colType.startsWith("tuple")) {
+            colType = "tuple";
+        } else if (colType.startsWith("dynamic")) {
+            colType = "dynamic";
+        } else if (colType.startsWith("variant")) {
+            colType = "variant";
         }
         switch (colType) {
             case "bool":
@@ -73,7 +85,13 @@ public class ChColReader extends AbstractColReader {
             case "uuid":
             case "json":
             case "object":
+            case "map":
+            case "array":
+            case "dynamic":
+            case "variant":
                 return STRING_VALUE_FETCHER;
+            case "tuple":
+                return TUPLE_VALUE_FETCHER;
             case "date":
             case "date32":
                 return DATE_VALUE_FETCHER;

--- a/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/execute/ChColReader.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/execute/ChColReader.java
@@ -71,6 +71,8 @@ public class ChColReader extends AbstractColReader {
             case "ipv4":
             case "ipv6":
             case "uuid":
+            case "json":
+            case "object":
                 return STRING_VALUE_FETCHER;
             case "date":
             case "date32":

--- a/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/execute/ChHooks.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/execute/ChHooks.java
@@ -147,7 +147,14 @@ public class ChHooks implements SessionHook {
     public PreparedStatement executeStatement(Connection conn, QueryRequest query) throws SQLException {
         try {
             PreparedStatement stmt = conn.prepareStatement(query.getQueryBody(), ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-            stmt.setFetchSize(Integer.MIN_VALUE);
+            // Negative fetch size would fail every statement: Integer.MIN_VALUE is the streaming idiom for
+            // MySQL Connector/J, but the bundled clickhouse-jdbc 0.9.x driver defaults to its V2
+            // implementation, whose StatementImpl#setFetchSize throws SQLException
+            // ("rows should be greater or equal to 0.") for any negative input. For ClickHouse, fetchSize
+            // is at most a client-side read buffer hint (V1) or a pure no-op (V2), never a row limit and
+            // not a streaming switch, so a fixed positive value is safe and consistent with
+            // explainStatement() below and the other JDBC plugins.
+            stmt.setFetchSize(200);
             return stmt;
         } catch (SQLException e) {
             throw ChExceptionUtils.toException(e);

--- a/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/execute/ChMetaProviderUtils.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/execute/ChMetaProviderUtils.java
@@ -114,9 +114,12 @@ public class ChMetaProviderUtils {
             }
 
             rdbColumn.setSqlType(safeToChTypes(dataType));
-            passerDatetime(dataType, rdbColumn);
-            passerNumeric(dataType, rdbColumn);
-            passerLength(dataType, rdbColumn);
+            // unknown server types not in ClickHouseTypes resolve to null; skip the passers to avoid NPE
+            if (rdbColumn.getSqlType() != null) {
+                passerDatetime(dataType, rdbColumn);
+                passerNumeric(dataType, rdbColumn);
+                passerLength(dataType, rdbColumn);
+            }
 
             // default
             String defaultDataKind = rs.getString("default_kind");

--- a/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/execute/ChTupleValueFetcher.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/execute/ChTupleValueFetcher.java
@@ -15,17 +15,32 @@
  */
 package com.clougence.clouddm.ds.clickhouse.execute;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 
 import com.clougence.clouddm.dsfamily.execute.fetcher.StringAsClobFetcher;
 import com.clougence.clouddm.sdk.execute.session.result.fetcher.ValueFetcherContext;
+import com.clougence.utils.io.IOUtils;
+import com.clougence.utils.io.output.DeferredFileOutputStream;
 
 /**
- * ClickHouse Tuple columns are read by the driver as Object[], whose toString() is
- * not readable, so format the elements explicitly.
+ * ClickHouse Tuple columns are read by the JDBC driver as a fully materialized Object[] (the
+ * driver's readTuple has no element-wise or streaming access), so this fetcher formats the
+ * value as bounded text.
+ * <p>
+ * Follows {@code ArrayValueFetcher}: output goes through a DeferredFileOutputStream (spills to
+ * file above 1MB), every element is bounded by {@code elementBytesLimit} and the whole cell by
+ * {@code columnBytesLimit} from {@link ValueFetcherContext} options; when a limit is hit the
+ * value is truncated and the complete flag is cleared.
  */
 public class ChTupleValueFetcher extends StringAsClobFetcher {
+
+    // m (mark): T = Type, V = dataValue / t (truncated): F = false, T = true
+    private static final String STOP_MARKER = ", {\"m\":\"T\",\"v\":\"...\",\"t\":\"T\"}";
 
     @Override
     protected StringValueFCD fetchState(String columnName, ResultSet rs, ValueFetcherContext ctx) throws SQLException {
@@ -35,9 +50,13 @@ public class ChTupleValueFetcher extends StringAsClobFetcher {
             if (value == null) {
                 fcd = StringValueFCD.ofInMemory(true, 0, 0, null, null);
             } else {
-                String str = formatTuple(value);
-                byte[] dataBytes = str.getBytes();
-                fcd = StringValueFCD.ofInMemory(true, str.length(), str.length(), str, dataBytes);
+                try {
+                    fcd = fetchTupleData(value, ctx);
+                } catch (Exception e) {
+                    String dataString = "ReadException: " + e.getMessage();
+                    byte[] dataBytes = dataString.getBytes();
+                    fcd = StringValueFCD.ofInMemory(false, 0, 0, dataString, dataBytes);
+                }
             }
             ctx.setContext(fcd);
         } else {
@@ -46,21 +65,113 @@ public class ChTupleValueFetcher extends StringAsClobFetcher {
         return fcd;
     }
 
-    private static String formatTuple(Object value) {
+    private StringValueFCD fetchTupleData(Object value, ValueFetcherContext ctx) throws IOException {
+        long columnBytesLimit = ctx.getOptions().getColumnBytesLimit();
+        long elementBytesLimit = ctx.getOptions().getElementBytesLimit();
+
+        DeferredFileOutputStream dfout = new DeferredFileOutputStream(1048576, tmpFile(ctx));
+        try (OutputStreamWriter out = new OutputStreamWriter(dfout)) {
+            long dataReadSize = 0;
+            boolean complete = true;
+
+            out.write("(");
+            boolean[] truncatedFlag = { false };
+            if (value instanceof Object[]) {
+                Object[] elements = (Object[]) value;
+                for (int i = 0; i < elements.length; i++) {
+                    String eleText = boundedText(elements[i], elementBytesLimit, truncatedFlag);
+                    boolean eleTruncated = truncatedFlag[0];
+                    truncatedFlag[0] = false;
+
+                    // check before writing so the cell never exceeds the limit; the marker
+                    // signals that the current and following elements were skipped
+                    if (i > 0 && dataReadSize + eleText.length() >= columnBytesLimit) {
+                        complete = false;
+                        out.write(STOP_MARKER);
+                        break;
+                    }
+                    if (i > 0) {
+                        out.write(", ");
+                    }
+                    out.write(eleText);
+                    dataReadSize += eleText.length();
+                    complete = complete && !eleTruncated;
+                }
+            } else {
+                String eleText = boundedText(value, elementBytesLimit, truncatedFlag);
+                out.write(eleText);
+                dataReadSize += eleText.length();
+                complete = !truncatedFlag[0];
+            }
+            out.write(")");
+            out.flush();
+            IOUtils.closeQuietly(dfout);
+
+            if (dfout.isInMemory()) {
+                byte[] bytes = dfout.getData();
+                return StringValueFCD.ofInMemory(complete, -1, bytes.length, new String(bytes), bytes);
+            } else {
+                File dfoutFile = dfout.getFile();
+                return StringValueFCD.ofInFile(complete, -1, dfoutFile.length(), dfoutFile);
+            }
+        }
+    }
+
+    private static String boundedText(Object value, long budget, boolean[] truncated) {
+        if (budget <= 0) {
+            truncated[0] = true;
+            return "";
+        }
         if (value == null) {
-            return "NULL";
+            return "null";
         }
         if (value instanceof Object[]) {
-            Object[] array = (Object[]) value;
-            StringBuilder sb = new StringBuilder("(");
-            for (int i = 0; i < array.length; i++) {
-                if (i > 0) {
-                    sb.append(", ");
-                }
-                sb.append(formatTuple(array[i]));
-            }
-            return sb.append(")").toString();
+            return boundedNestedTuple((Object[]) value, budget, truncated);
         }
-        return value.toString();
+        if (value instanceof List) {
+            return boundedNestedArray((List<?>) value, budget, truncated);
+        }
+        String text = value.toString();
+        if (text.length() > budget) {
+            truncated[0] = true;
+            return text.substring(0, (int) budget);
+        }
+        return text;
+    }
+
+    private static String boundedNestedTuple(Object[] elements, long budget, boolean[] truncated) {
+        StringBuilder sb = new StringBuilder("(");
+        long used = 1;
+        for (int i = 0; i < elements.length; i++) {
+            if (i > 0) {
+                sb.append(", ");
+                used += 2;
+            }
+            sb.append(boundedText(elements[i], budget - used, truncated));
+            used = sb.length();
+            if (truncated[0] || used >= budget) {
+                truncated[0] = true;
+                break;
+            }
+        }
+        return sb.append(")").toString();
+    }
+
+    private static String boundedNestedArray(List<?> elements, long budget, boolean[] truncated) {
+        StringBuilder sb = new StringBuilder("[");
+        long used = 1;
+        for (int i = 0; i < elements.size(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+                used += 2;
+            }
+            sb.append(boundedText(elements.get(i), budget - used, truncated));
+            used = sb.length();
+            if (truncated[0] || used >= budget) {
+                truncated[0] = true;
+                break;
+            }
+        }
+        return sb.append("]").toString();
     }
 }

--- a/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/execute/ChTupleValueFetcher.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-clickhouse/src/main/java/com/clougence/clouddm/ds/clickhouse/execute/ChTupleValueFetcher.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.clougence.clouddm.ds.clickhouse.execute;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import com.clougence.clouddm.dsfamily.execute.fetcher.StringAsClobFetcher;
+import com.clougence.clouddm.sdk.execute.session.result.fetcher.ValueFetcherContext;
+
+/**
+ * ClickHouse Tuple columns are read by the driver as Object[], whose toString() is
+ * not readable, so format the elements explicitly.
+ */
+public class ChTupleValueFetcher extends StringAsClobFetcher {
+
+    @Override
+    protected StringValueFCD fetchState(String columnName, ResultSet rs, ValueFetcherContext ctx) throws SQLException {
+        StringValueFCD fcd;
+        if (ctx.getContext() == null || !(ctx.getContext() instanceof StringValueFCD)) {
+            Object value = rs.getObject(columnName);
+            if (value == null) {
+                fcd = StringValueFCD.ofInMemory(true, 0, 0, null, null);
+            } else {
+                String str = formatTuple(value);
+                byte[] dataBytes = str.getBytes();
+                fcd = StringValueFCD.ofInMemory(true, str.length(), str.length(), str, dataBytes);
+            }
+            ctx.setContext(fcd);
+        } else {
+            fcd = (StringValueFCD) ctx.getContext();
+        }
+        return fcd;
+    }
+
+    private static String formatTuple(Object value) {
+        if (value == null) {
+            return "NULL";
+        }
+        if (value instanceof Object[]) {
+            Object[] array = (Object[]) value;
+            StringBuilder sb = new StringBuilder("(");
+            for (int i = 0; i < array.length; i++) {
+                if (i > 0) {
+                    sb.append(", ");
+                }
+                sb.append(formatTuple(array[i]));
+            }
+            return sb.append(")").toString();
+        }
+        return value.toString();
+    }
+}

--- a/backend/clouddm-utils/cg-schema/src/main/java/com/clougence/adapter/clickhouse/ClickHouseTypes.java
+++ b/backend/clouddm-utils/cg-schema/src/main/java/com/clougence/adapter/clickhouse/ClickHouseTypes.java
@@ -94,7 +94,20 @@ public enum ClickHouseTypes implements FieldType {
     Polygon("Polygon", JDBCType.VARCHAR),
     MultiPolygon("MultiPolygon", JDBCType.VARCHAR),
     LowCardinality("LowCardinality", JDBCType.VARCHAR),
-    Ring("Ring", JDBCType.VARCHAR),;
+    Ring("Ring", JDBCType.VARCHAR),
+
+    // types introduced by newer ClickHouse servers (24.x ~ 26.x)
+    JSON("JSON", JDBCType.VARCHAR),
+    Object("Object", JDBCType.VARCHAR),
+    Dynamic("Dynamic", JDBCType.VARCHAR),
+    Variant("Variant", JDBCType.VARCHAR),
+    Vector("Vector", JDBCType.VARCHAR),
+    BFloat16("BFloat16", JDBCType.REAL),
+    Time("Time", JDBCType.TIME),
+    Time32("Time32", JDBCType.TIME),
+    Time64("Time64", JDBCType.TIME),
+    LineString("LineString", JDBCType.VARCHAR),
+    MultiLineString("MultiLineString", JDBCType.VARCHAR),;
 
     //    LowCardinality("LowCardinality", Fmt.of("LowCardinality(?)")),
     private final String           codeKey;

--- a/package/pkg/builtin-drivers/built-in-drivers.xml
+++ b/package/pkg/builtin-drivers/built-in-drivers.xml
@@ -40,6 +40,9 @@
     <driver driverFamily="MongoDB Driver" version="5.9.0">
         <resource type="maven">org.mongodb:mongodb-driver-sync:5.9.0</resource>
     </driver>
+    <driver driverFamily="ClickHouse JDBC" version="0.9.8">
+        <resource type="maven">com.clickhouse:clickhouse-jdbc:0.9.8</resource>
+    </driver>
     <driver driverFamily="ClickHouse JDBC" version="0.9.7">
         <resource type="maven">com.clickhouse:clickhouse-jdbc:0.9.7</resource>
     </driver>

--- a/package/pkg/builtin-drivers/built-in-drivers.xml
+++ b/package/pkg/builtin-drivers/built-in-drivers.xml
@@ -40,9 +40,6 @@
     <driver driverFamily="MongoDB Driver" version="5.9.0">
         <resource type="maven">org.mongodb:mongodb-driver-sync:5.9.0</resource>
     </driver>
-    <driver driverFamily="ClickHouse JDBC" version="0.9.8">
-        <resource type="maven">com.clickhouse:clickhouse-jdbc:0.9.8</resource>
-    </driver>
     <driver driverFamily="ClickHouse JDBC" version="0.9.7">
         <resource type="maven">com.clickhouse:clickhouse-jdbc:0.9.7</resource>
     </driver>


### PR DESCRIPTION
## Summary

This PR fixes ClickHouse driver compatibility for modern ClickHouse servers (25.x/26.x) in the ds-clickhouse plugin:

  - Fixes **the rows should be greater or equal to 0**. error that made every SQL statement fail. ChHooks applied the MySQL streaming idiom setFetchSize(Integer.MIN_VALUE), which the bundled clickhouse-jdbc 0.9.x V2 driver rejects for negative values; it now uses a fixed positive fetch size.
  - Adds support for new ClickHouse data types — JSON, Object, Dynamic, Variant, Vector, BFloat16, Time/Time32/Time64, and LineString/MultiLineString — in ClickHouseTypes.
  - Prevents an NPE when loading metadata for tables containing unrecognized types.
  - Renders query results for JSON, Map (incl. Map(String, Dynamic)), Array, Tuple, Dynamic, and Variant columns, including a new ChTupleValueFetcher that formats Tuple values readably instead of raw Object[] output.

  All changes verified against a real ClickHouse 25.3.14.14 instance using the exact driver jars shipped in the released package.



## Related Issues

Not yet

## Type of Change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

<!-- List the main implementation changes. -->

1. Fixed rows should be greater or equal to 0. error on every statement
    - ChHooks.executeStatement used setFetchSize(Integer.MIN_VALUE) — the MySQL Connector/J streaming idiom.
    - The bundled clickhouse-jdbc 0.9.x driver defaults to its V2 implementation, whose StatementImpl#setFetchSize throws SQLException("rows should be greater or equal to 0.") for any negative input, breaking every query.
    - Changed to a fixed positive value (200), consistent with explainStatement() and other JDBC plugins. ClickHouse's fetchSize is at most a client-side read buffer hint, never a row limit or streaming switch.
2. Added new ClickHouse data types to ClickHouseTypes
    - JSON, Object, Dynamic, Variant, Vector, BFloat16, Time, Time32, Time64, LineString, MultiLineString.
    - Appended at the end of the enum to preserve existing ordinals.
3. Prevented NPE when loading metadata for unknown types
    - ChMetaProviderUtils.convertColumn: safeToChTypes returns null for types not in the enum, and the follow-up passers (passerDatetime/passerNumeric/passerLength) switched on null → NPE when browsing a table containing any unrecognized type.
    - Passers are now skipped when the type resolves to null.
4. Added query result support for container and new types (ChColReader)
    - json, object, map, array, dynamic, variant now map to STRING_VALUE_FETCHER (values were previously displayed as "Unsupported ... type.").
    - New ChTupleValueFetcher: the driver reads Tuple columns as Object[], whose toString() yields unreadable garbage ([Ljava.lang.Object;@7334aada). The fetcher formats nested tuples recursively, e.g. (x, 42, [a, b]).

## Test Plan

<!-- Describe the commands or manual checks you ran. -->

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [x] Frontend lint / build
- [x] Backend build
- [x] Manual verification

Details:

- Verified against a real ClickHouse 25.3.14.14 instance using the exact bundled 0.9.7 driver jars (same as the released package).
- Metadata loading (system.columns query + type matching) succeeds for JSON, Map(String, String), Map(String, Dynamic), Tuple, Array, Dynamic, and Variant columns without NPE.
- Query results render correctly for all of the above:
    - JSON → {a=1, b=x}
    - Map(String, Dynamic) → {d1=42, d2=str}
    - Tuple(String, UInt64, Array(String)) → (x, 42, [a, b])
    - Array(String) → ['x', 'y']
    - Dynamic → hello, Variant(String, UInt64) → 456
- All existing column types (Bool/Int*/UInt*/Float*/Decimal*/String/FixedString/UUID/IPv4/IPv6/Date/DateTime*/Enum) retain their previous fetcher mappings.


## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [ ] Documentation was updated when behavior or usage changed.
- [x] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
