### PR TITLE
fix(sql-analysis): handle non-select domains in function arguments

### DIFF
--- a/backend/clouddm-plugins/clouddm-sql/sqlc-common/src/main/java/com/clougence/sql/common/analysis/lineage/AbstractLineageAnalysisSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sqlc-common/src/main/java/com/clougence/sql/common/analysis/lineage/AbstractLineageAnalysisSpi.java
@@ -62,7 +62,9 @@ public abstract class AbstractLineageAnalysisSpi implements LineageAnalysisSpi {
     private List<MutableColumnLineage> analyzeColumns(String uid, long dsID, Map<UmiTypes, Object> levelsParam, List<RuleDomain> domains, ColumnScope outerScope) {
         List<List<MutableColumnLineage>> result = new ArrayList<>();
         for (RuleDomain domain : domains) {
-            RdbSelectDomain selectDomain = (RdbSelectDomain) domain;
+            if (!(domain instanceof RdbSelectDomain selectDomain)) {
+                continue;
+            }
             List<MutableColumnLineage> selectItems = new ArrayList<>();
             if (CollectionUtils.isNotEmpty(selectDomain.getChildren())) {
                 boolean naturalJoin = selectDomain.getOptions() != null && Boolean.parseBoolean(selectDomain.getOptions().get(NATURAL_JOIN_OPTION));

--- a/backend/clouddm-plugins/clouddm-sql/sqlc-common/src/main/java/com/clougence/sql/common/analysis/secrules/builder/FunctionArgBuilder.java
+++ b/backend/clouddm-plugins/clouddm-sql/sqlc-common/src/main/java/com/clougence/sql/common/analysis/secrules/builder/FunctionArgBuilder.java
@@ -43,8 +43,9 @@ public class FunctionArgBuilder extends AbstractDomainBuilder {
         }
 
         if (status == DomainSource.SELECT) {
-            RdbSelectDomain domain = (RdbSelectDomain) list.get(0);
-            domain.setMode(RdbQueryMode.SUB_CALL);
+            if (list.get(0) instanceof RdbSelectDomain domain) {
+                domain.setMode(RdbQueryMode.SUB_CALL);
+            }
             this.callArgsDomain.getDomains().addAll(list);
             return;
         }


### PR DESCRIPTION
## Summary

Prevent SQL security and lineage analysis from throwing `ClassCastException` when a function argument produces a non-select domain, such as a `CASE` expression containing an aggregate call.

## Related Issues

None

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Only mark function-argument domains as `SUB_CALL` when the parsed domain is an `RdbSelectDomain`.
- Ignore non-select domains while computing column lineage instead of casting them unconditionally.
- Preserve non-select domains for downstream security analysis.

## Test Plan

- [ ] Not tested (explain why below)
- [x] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [x] Backend build
- [ ] Manual verification

Details:

```text
JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew -Dorg.gradle.java.home=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home :sqlc-common:compileJava

JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew -Dorg.gradle.java.home=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home :s-test:test --tests com.clougence.clouddm.ds.permission.mysql.MySql80PermissionTextTest --tests com.clougence.clouddm.ds.secdomain.SecDomainTextTest

2719 tests completed, 2719 passed, 0 failed, 0 skipped.
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [x] Documentation was updated when behavior or usage changed. (Not applicable: no user-facing behavior or usage change.)
- [ ] Tests were added or updated for behavior changes. (Existing SQL fixture suites cover the affected analysis paths.)
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.