### PR TITLE
fix(frontend): keep duration: 0 notifications visible

### DIFF
--- a/frontend/src/utils/toast.js
+++ b/frontend/src/utils/toast.js
@@ -9,17 +9,23 @@ function stripHtml(html) {
   return tmp.textContent || tmp.innerText || '';
 }
 
+function normalizeDuration(duration) {
+  if (duration === undefined || duration === null) return DEFAULT_DURATION;
+  // iView uses 0 for persistent messages, while vue-sonner uses Infinity.
+  return duration === 0 ? Infinity : duration;
+}
+
 function resolve(msg, duration, onClose) {
   if (typeof msg === 'object' && msg !== null) {
     return {
       content: stripHtml(msg.content || ''),
-      duration: msg.duration ?? DEFAULT_DURATION,
+      duration: normalizeDuration(msg.duration),
       onClose: msg.onClose
     };
   }
   return {
     content: stripHtml(msg || ''),
-    duration: duration ?? DEFAULT_DURATION,
+    duration: normalizeDuration(duration),
     onClose
   };
 }


### PR DESCRIPTION
## Summary

Preserve the legacy iView `duration: 0` contract when notifications are forwarded to vue-sonner.

The compatibility wrapper previously passed `0` through unchanged. vue-sonner resolves durations with a truthy fallback, so `0` became its default lifetime and notifications that were meant to remain visible disappeared after a few seconds. The wrapper now translates `0` to vue-sonner's documented persistent value, `Infinity`.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Normalize omitted durations to the existing default.
- Translate the iView persistent duration (`0`) to vue-sonner's persistent duration (`Infinity`).
- Apply the normalization to both object-style and positional message calls.

## Test Plan

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [x] Frontend lint / build
- [ ] Backend build
- [ ] Manual verification

Details:

```text
npx eslint src/utils/toast.js
Verified vue-sonner's duration fallback and documented Infinity behavior against the installed dependency source.
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [ ] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
