### PR TITLE
refactor(frontend): drive breadcrumbs from route metadata

### DIFF
--- a/frontend/src/components/layout/AppContentHeader.vue
+++ b/frontend/src/components/layout/AppContentHeader.vue
@@ -2,12 +2,16 @@
   <header class="app-content-header">
     <div class="app-content-header__left">
       <h1 class="app-content-header__title">
+        <span v-if="pageBreadcrumbs.length > 2" class="app-content-header__mobile-ellipsis" aria-hidden="true" />
         <template v-for="(item, index) in pageBreadcrumbs" :key="`${item.label}-${index}`">
           <button
             v-if="item.event"
             type="button"
             class="app-content-header__crumb app-content-header__crumb-button"
-            :class="{ 'is-current': index === pageBreadcrumbs.length - 1 }"
+            :class="{
+              'is-current': index === pageBreadcrumbs.length - 1,
+              'is-mobile-previous': index === pageBreadcrumbs.length - 2
+            }"
             @click="handleBreadcrumbEvent(item.event)"
           >
             {{ item.label }}
@@ -15,15 +19,31 @@
           <router-link
             v-else-if="item.to"
             class="app-content-header__crumb"
-            :class="{ 'is-current': index === pageBreadcrumbs.length - 1 }"
+            :class="{
+              'is-current': index === pageBreadcrumbs.length - 1,
+              'is-mobile-previous': index === pageBreadcrumbs.length - 2
+            }"
             :to="item.to"
           >
             {{ item.label }}
           </router-link>
-          <span v-else class="app-content-header__crumb" :class="{ 'is-current': index === pageBreadcrumbs.length - 1 }">
+          <span
+            v-else
+            class="app-content-header__crumb"
+            :class="{
+              'is-current': index === pageBreadcrumbs.length - 1,
+              'is-mobile-previous': index === pageBreadcrumbs.length - 2
+            }"
+          >
             {{ item.label }}
           </span>
-          <span v-if="index < pageBreadcrumbs.length - 1" class="app-content-header__separator">/</span>
+          <span
+            v-if="index < pageBreadcrumbs.length - 1"
+            class="app-content-header__separator"
+            :class="{ 'is-mobile-visible': index === pageBreadcrumbs.length - 2 }"
+          >
+            /
+          </span>
         </template>
       </h1>
     </div>
@@ -134,253 +154,21 @@ export default {
 
       return this.$t('pei-zhi');
     },
-    pageSubTitle() {
-      const path = this.$route.path;
-
-      if (path === '/cicd/create') {
-        return this.$t('chuang-jian-xiang-mu');
-      }
-      if (/^\/cicd\/[^/]+\/config$/.test(path)) {
-        return this.$t('cicd-pei-zhi-xiang');
-      }
-      if (/^\/cicd\/[^/]+$/.test(path)) {
-        return this.$t('cicd-bian-geng-liu-gai-lan');
-      }
-
-      return '';
-    },
     pageBreadcrumbs() {
-      const path = this.$route.path;
-      const securityRoot = {
-        label: this.$t('an-quan-gui-fan'),
-        to: {
-          path: '/data-access/rules',
-          query: { tab: 'security' }
-        }
-      };
-      const securityTemplateRoot = {
-        ...securityRoot,
-        to: {
-          path: '/data-access/rules',
-          query: { tab: 'template' }
-        }
-      };
-      const securityDetail = (specId) => ({
-        label: this.$t('gui-ze-xiang-qing'),
-        to: {
-          path: `/system/dmspec/${specId}`,
-          query: this.$route.query.ruleKind ? { ruleKind: this.$route.query.ruleKind } : {}
-        }
-      });
-      const cicdRoot = { label: this.$t('nav-ci-cd'), to: '/cicd' };
-      const ticketRoot = { label: this.$t('gong-dan'), to: '/ticket' };
-      const flowDetail = (flowId) => ({
-        label: this.$t('cicd-bian-geng-liu-xiang-qing'),
-        to: flowId ? `/cicd/${flowId}` : ''
-      });
-      const machineRoot = {
-        label: this.$t('nav-cha-xun-ji-qi-lie-biao'),
-        to: '/data-access/cluster'
-      };
-      const roleRoot = {
-        label: this.$t('jiao-se'),
-        to: '/manager/role'
-      };
-      const accountRoot = {
-        label: this.$t('nav-zhang-hu'),
-        to: '/manager/account'
-      };
+      if (this.$route.meta.breadcrumbType === 'datasource-form') {
+        return this.dataSourceBreadcrumbs();
+      }
 
-      if (path === '/manager/account/batch_authorization') {
-        return [accountRoot, { label: this.$t('pi-liang-shou-quan'), to: this.$route.fullPath }];
+      const routeBreadcrumbs = this.$route.meta.breadcrumbs;
+      if (!Array.isArray(routeBreadcrumbs) || !routeBreadcrumbs.length) {
+        return [{ label: this.pageTitle, to: '' }];
       }
-      if (
-        path === '/manager/account/batch_authorization/permissions' ||
-        (path === '/system/account/authdm/batch' && this.$route.query.type === 'batch')
-      ) {
-        const batchAuthorizationQuery = {
-          operation: this.$route.query.operation,
-          uids: this.$route.query.uids
-        };
-        return [
-          accountRoot,
-          {
-            label: this.$t('pi-liang-shou-quan'),
-            to: { path: '/manager/account/batch_authorization', query: batchAuthorizationQuery }
-          },
-          { label: this.$t('xuan-ze-quan-xian'), to: this.$route.fullPath }
-        ];
-      }
-      if (path === '/system/authdm' || /^\/system\/account\/authdm\/[^/]+$/.test(path)) {
-        return [accountRoot, { label: this.$t('shou-quan'), to: this.$route.fullPath }];
-      }
-      if (path === '/data-access/rules' || path === '/data-access/rules/') {
-        return [{ ...securityRoot, to: this.$route.fullPath }];
-      }
-      if (path === '/data-access/rules/create') {
-        return [
-          securityTemplateRoot,
-          {
-            label: this.$t('xin-jian-gui-ze-mo-ban'),
-            to: this.$route.fullPath
-          }
-        ];
-      }
-      if (/^\/data-access\/rules\/detail\/[^/]+$/.test(path)) {
-        return [
-          securityTemplateRoot,
-          {
-            label: this.$t('gui-ze-mo-ban-xiang-qing'),
-            to: this.$route.fullPath
-          }
-        ];
-      }
-      if (/^\/system\/dmspec\/[^/]+$/.test(path)) {
-        return [
-          securityRoot,
-          {
-            ...securityDetail(this.$route.params.specId),
-            to: this.$route.fullPath
-          }
-        ];
-      }
-      if (/^\/system\/dmspec\/[^/]+\/rule\/[^/]+\/range$/.test(path)) {
-        return [
-          securityRoot,
-          securityDetail(this.$route.params.specId),
-          {
-            label: this.$t('gui-ze-fan-wei'),
-            to: this.$route.fullPath
-          }
-        ];
-      }
-      if (/^\/system\/dmspec\/[^/]+\/rule\/[^/]+\/detail$/.test(path)) {
-        return [
-          securityRoot,
-          securityDetail(this.$route.params.specId),
-          {
-            label: this.$route.query.ruleName || this.$t('gui-ze-xiang-qing'),
-            to: this.$route.fullPath
-          }
-        ];
-      }
-      if (path === '/cicd' || path === '/cicd/') {
-        return [cicdRoot];
-      }
-      if (path === '/cicd/create') {
-        return [cicdRoot, { label: this.$t('chuang-jian-xiang-mu'), to: path }];
-      }
-      if (/^\/ticket\/[^/]+$/.test(path)) {
-        return [ticketRoot, { label: this.$t('gong-dan-xiang-qing'), to: this.$route.fullPath }];
-      }
-      if (path === '/datasource/add') {
-        const dsType = this.$route.query.dsType;
-        const instanceId = this.$route.query.instanceId;
-        const isEditMode = this.$route.query.mode === 'edit';
-        const dsDisplayName = this.dataSourceDisplayName(dsType);
-        const actionLabel = isEditMode ? this.$t('bian-ji') : this.$t('xin-zeng-shu-ju-yuan');
-        const actionBreadcrumb = isEditMode
-          ? { label: actionLabel, to: '/datasource' }
-          : { label: actionLabel, event: EVENT_BUS_NAME_LIST.SHOW_ADD_DATASOURCE_TYPE_MODAL };
-        const breadcrumbs = [
-          {
-            label: this.$t('nav-shu-ju-ku-guan-li'),
-            to: '/datasource'
-          },
-          actionBreadcrumb
-        ];
-        if (dsDisplayName) {
-          breadcrumbs.push({
-            label: isEditMode && instanceId ? `${dsDisplayName}(${instanceId})` : dsDisplayName,
-            to: ''
-          });
-        }
-        return breadcrumbs;
-      }
-      if (/^\/cicd\/[^/]+\/release-flow\/add$/.test(path)) {
-        const flowId = this.$route.params.id;
-        return [cicdRoot, flowDetail(flowId), { label: this.$t('tian-jia-git-ops'), to: path }];
-      }
-      if (/^\/cicd\/[^/]+\/config$/.test(path)) {
-        const flowId = this.$route.params.id;
-        return [cicdRoot, flowDetail(flowId), { label: this.$t('cicd-pei-zhi-xiang'), to: path }];
-      }
-      if (/^\/cicd\/[^/]+$/.test(path)) {
-        return [cicdRoot, { label: this.$t('cicd-bian-geng-liu-xiang-qing'), to: path }];
-      }
-      if (path === '/data-access/cluster' || path === '/data-access/cluster/') {
-        return [{ ...machineRoot, to: this.$route.fullPath }];
-      }
-      if (/^\/data-access\/cluster\/list\/[^/]+$/.test(path)) {
-        return [machineRoot, { label: this.$t('ji-qi-lie-biao'), to: this.$route.fullPath }];
-      }
-      if (path === '/manager/role' || path === '/manager/role/') {
-        return [{ ...roleRoot, to: this.$route.fullPath }];
-      }
-      if (path === '/manager/role/create') {
-        return [roleRoot, { label: this.$t('chuang-jian-jiao-se'), to: this.$route.fullPath }];
-      }
-      if (/^\/manager\/role\/[^/]+\/edit$/.test(path)) {
-        return [roleRoot, { label: this.$t('bian-ji-jue-se'), to: this.$route.fullPath }];
-      }
-      if (/^\/manager\/role\/[^/]+\/view$/.test(path)) {
-        return [roleRoot, { label: this.$t('cha-kan-jue-se'), to: this.$route.fullPath }];
-      }
-      if (path === '/integrations/git/create') {
-        return [
-          { label: this.$t('nav-git-ops'), to: '/integrations/git' },
-          { label: this.$t('xin-zeng'), to: path }
-        ];
-      }
-      if (/^\/integrations\/git\/[^/]+\/edit$/.test(path)) {
-        return [
-          { label: this.$t('nav-git-ops'), to: '/integrations/git' },
-          { label: this.$t('bian-ji'), to: path }
-        ];
-      }
-      if (path === '/integrations/im/create') {
-        return [
-          { label: this.$t('nav-webhook'), to: '/integrations/im' },
-          { label: this.$t('xin-zeng'), to: path }
-        ];
-      }
-      if (/^\/integrations\/im\/[^/]+\/edit$/.test(path)) {
-        return [
-          { label: this.$t('nav-webhook'), to: '/integrations/im' },
-          { label: this.$t('bian-ji'), to: path }
-        ];
-      }
-      if (path === '/integrations/sso/create') {
-        return [
-          { label: this.$t('nav-sso'), to: '/integrations/sso' },
-          { label: this.$t('xin-zeng'), to: path }
-        ];
-      }
-      if (/^\/integrations\/sso\/[^/]+\/edit$/.test(path)) {
-        return [
-          { label: this.$t('nav-sso'), to: '/integrations/sso' },
-          { label: this.$t('pei-zhi'), to: path }
-        ];
-      }
-      if (path === '/integrations/approval/create') {
-        return [
-          { label: this.$t('nav-shen-pi-yin-qing'), to: '/integrations/approval' },
-          { label: this.$t('xin-zeng'), to: path }
-        ];
-      }
-      if (/^\/integrations\/approval\/[^/]+\/edit$/.test(path)) {
-        return [
-          { label: this.$t('nav-shen-pi-yin-qing'), to: '/integrations/approval' },
-          { label: this.$t('pei-zhi'), to: path }
-        ];
-      }
-      if (this.pageSubTitle) {
-        return [
-          { label: this.pageTitle, to: path },
-          { label: this.pageSubTitle, to: path }
-        ];
-      }
-      return [{ label: this.pageTitle, to: path }];
+
+      return routeBreadcrumbs.map((item, index) => ({
+        label: this.resolveBreadcrumbLabel(item),
+        to: index === routeBreadcrumbs.length - 1 ? '' : this.resolveBreadcrumbTarget(item.to),
+        event: index === routeBreadcrumbs.length - 1 ? '' : item.event
+      }));
     }
   },
   methods: {
@@ -394,6 +182,32 @@ export default {
       }
       this.$bus.emit(eventName);
     },
+    resolveBreadcrumbLabel(item) {
+      const label = item.queryLabel ? this.$route.query[item.queryLabel] || this.$t(item.labelKey) : this.$t(item.labelKey);
+      const value = item.param ? this.$route.params[item.param] : '';
+      return value ? `${label} #${value}` : label;
+    },
+    resolveBreadcrumbTarget(target) {
+      return typeof target === 'function' ? target(this.$route) : target || '';
+    },
+    dataSourceBreadcrumbs() {
+      const dsType = this.$route.query.dsType;
+      const instanceId = this.$route.query.instanceId;
+      const isEditMode = this.$route.query.mode === 'edit';
+      const dsDisplayName = this.dataSourceDisplayName(dsType);
+      const actionBreadcrumb = isEditMode
+        ? { label: this.$t('bian-ji'), to: '/datasource' }
+        : { label: this.$t('xin-zeng-shu-ju-yuan'), event: EVENT_BUS_NAME_LIST.SHOW_ADD_DATASOURCE_TYPE_MODAL };
+      const breadcrumbs = [{ label: this.$t('nav-shu-ju-ku-guan-li'), to: '/datasource' }, actionBreadcrumb];
+      if (dsDisplayName) {
+        breadcrumbs.push({ label: isEditMode && instanceId ? `${dsDisplayName} (${instanceId})` : dsDisplayName, to: '' });
+      }
+      return breadcrumbs.map((item, index) => ({
+        ...item,
+        to: index === breadcrumbs.length - 1 ? '' : item.to,
+        event: index === breadcrumbs.length - 1 ? '' : item.event
+      }));
+    },
     dataSourceDisplayName(dsType) {
       if (!dsType) {
         return '';
@@ -406,18 +220,21 @@ export default {
 
 <style lang="less" scoped>
 .app-content-header__title {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
+  width: 100%;
   min-width: 0;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
 .app-content-header__crumb {
-  color: #4b5563;
-  font-size: 18px;
-  font-weight: 600;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+  font-weight: 500;
   line-height: 24px;
+  white-space: nowrap;
   text-decoration: none;
   transition: color 0.18s ease;
 
@@ -426,7 +243,17 @@ export default {
   }
 
   &.is-current {
-    color: #1f2937;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-primary);
+    font-size: 18px;
+    font-weight: 600;
+    text-overflow: ellipsis;
+
+    &:hover {
+      color: var(--text-primary);
+    }
   }
 }
 
@@ -440,7 +267,31 @@ export default {
 }
 
 .app-content-header__separator {
-  color: #6b7280;
-  font-weight: 600;
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.app-content-header__mobile-ellipsis {
+  display: none;
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  font-size: 14px;
+
+  &::before {
+    content: '\2026';
+  }
+}
+
+@media (max-width: 767px) {
+  .app-content-header__crumb:not(.is-current):not(.is-mobile-previous),
+  .app-content-header__separator:not(.is-mobile-visible) {
+    display: none;
+  }
+
+  .app-content-header__mobile-ellipsis {
+    display: inline;
+  }
 }
 </style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -33,7 +33,10 @@ const systemChildren = [
     path: '/settings/preferences',
     name: '/settings/preferences',
     component: Preference,
-    meta: { requiredAuth: 'RDP_PRI_USER_KV_CONF_R' }
+    meta: {
+      requiredAuth: 'RDP_PRI_USER_KV_CONF_R',
+      breadcrumbs: [{ labelKey: 'nav-tong-yong' }]
+    }
   },
   {
     path: 'preference',
@@ -60,19 +63,30 @@ const routes = [
       {
         path: 'cicd',
         name: 'CICD',
-        component: () => import(/* webpackChunkName: "cicd" */ '@/views/cicd/index')
+        component: () => import(/* webpackChunkName: "cicd" */ '@/views/cicd/index'),
+        meta: { breadcrumbs: [{ labelKey: 'nav-ci-cd' }] }
       },
       {
         path: 'cicd/create',
         name: 'cicd/create',
         component: () => import(/* webpackChunkName: "cicd-release-flow" */ '@/views/cicd/ReleaseFlowPage'),
-        meta: { requiredAuth: 'DM_CICD_FLOW_MANAGE' }
+        meta: {
+          requiredAuth: 'DM_CICD_FLOW_MANAGE',
+          breadcrumbs: [{ labelKey: 'nav-ci-cd', to: '/cicd' }, { labelKey: 'chuang-jian-xiang-mu' }]
+        }
       },
       {
         path: 'cicd/:id/release-flow/add',
         name: 'cicd/release-flow/add',
         component: () => import(/* webpackChunkName: "cicd-release-flow" */ '@/views/cicd/ReleaseFlowPage'),
-        meta: { requiredAuth: 'DM_CICD_FLOW_MANAGE' }
+        meta: {
+          requiredAuth: 'DM_CICD_FLOW_MANAGE',
+          breadcrumbs: [
+            { labelKey: 'nav-ci-cd', to: '/cicd' },
+            { labelKey: 'cicd-bian-geng-liu-xiang-qing', param: 'id', to: (route) => `/cicd/${route.params.id}` },
+            { labelKey: 'tian-jia-git-ops' }
+          ]
+        }
       },
       {
         path: 'cicd/:id/change-records',
@@ -81,7 +95,14 @@ const routes = [
       {
         path: 'cicd/:id/config',
         name: 'cicd/config',
-        component: () => import(/* webpackChunkName: "cicd-release-flow-config" */ '@/views/cicd/flowConfig')
+        component: () => import(/* webpackChunkName: "cicd-release-flow-config" */ '@/views/cicd/flowConfig'),
+        meta: {
+          breadcrumbs: [
+            { labelKey: 'nav-ci-cd', to: '/cicd' },
+            { labelKey: 'cicd-bian-geng-liu-xiang-qing', param: 'id', to: (route) => `/cicd/${route.params.id}` },
+            { labelKey: 'cicd-pei-zhi-xiang' }
+          ]
+        }
       },
       {
         path: 'cicd/change/:id',
@@ -90,22 +111,38 @@ const routes = [
       {
         path: 'cicd/:id',
         name: 'cicd/id',
-        component: () => import(/* webpackChunkName: "ticket" */ '../views/cicd/flowDetail')
+        component: () => import(/* webpackChunkName: "ticket" */ '../views/cicd/flowDetail'),
+        meta: {
+          breadcrumbs: [
+            { labelKey: 'nav-ci-cd', to: '/cicd' },
+            { labelKey: 'cicd-bian-geng-liu-xiang-qing', param: 'id' }
+          ]
+        }
       },
       {
         path: 'ticket',
         name: 'Ticket',
-        component: Ticket
+        component: Ticket,
+        meta: { breadcrumbs: [{ labelKey: 'gong-dan' }] }
       },
       {
         path: '/ticket/:id',
         name: 'Ticket/id',
-        component: () => import(/* webpackChunkName: "ticket" */ '../views/ticket/ticketDetail')
+        component: () => import(/* webpackChunkName: "ticket" */ '../views/ticket/ticketDetail'),
+        meta: {
+          breadcrumbs: [
+            { labelKey: 'gong-dan', to: '/ticket' },
+            { labelKey: 'gong-dan-xiang-qing', param: 'id' }
+          ]
+        }
       },
       {
         path: '/ticket_create',
         name: 'Ticket_create',
-        component: () => import(/* webpackChunkName: "ticket" */ '../views/ticket/ticket')
+        component: () => import(/* webpackChunkName: "ticket" */ '../views/ticket/ticket'),
+        meta: {
+          breadcrumbs: [{ labelKey: 'gong-dan', to: '/ticket' }, { labelKey: 'xin-jian' }]
+        }
       },
       {
         path: 'dmdatasource',

--- a/frontend/src/router/system.js
+++ b/frontend/src/router/system.js
@@ -2,17 +2,24 @@ export default [
   {
     path: '/integrations/git',
     name: 'DMDevops',
-    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/devops')
+    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/devops'),
+    meta: { breadcrumbs: [{ labelKey: 'nav-git-ops' }] }
   },
   {
     path: '/integrations/git/create',
     name: 'DMDevopsCreate',
-    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/devops/form')
+    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/devops/form'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'nav-git-ops', to: '/integrations/git' }, { labelKey: 'xin-zeng' }]
+    }
   },
   {
     path: '/integrations/git/:scmId/edit',
     name: 'DMDevopsEdit',
-    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/devops/form')
+    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/devops/form'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'nav-git-ops', to: '/integrations/git' }, { labelKey: 'bian-ji' }]
+    }
   },
   {
     path: 'devops',
@@ -21,17 +28,24 @@ export default [
   {
     path: '/integrations/sso',
     name: 'DMSso',
-    component: () => import(/* webpackChunkName: "ccsystem-sso" */ '@/views/system/sso/index')
+    component: () => import(/* webpackChunkName: "ccsystem-sso" */ '@/views/system/sso/index'),
+    meta: { breadcrumbs: [{ labelKey: 'nav-sso' }] }
   },
   {
     path: '/integrations/sso/create',
     name: 'DMSsoCreate',
-    component: () => import(/* webpackChunkName: "ccsystem-sso" */ '@/views/system/sso/form')
+    component: () => import(/* webpackChunkName: "ccsystem-sso" */ '@/views/system/sso/form'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'nav-sso', to: '/integrations/sso' }, { labelKey: 'xin-zeng' }]
+    }
   },
   {
     path: '/integrations/sso/:type/edit',
     name: 'DMSsoEdit',
-    component: () => import(/* webpackChunkName: "ccsystem-sso" */ '@/views/system/sso/form')
+    component: () => import(/* webpackChunkName: "ccsystem-sso" */ '@/views/system/sso/form'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'nav-sso', to: '/integrations/sso' }, { labelKey: 'pei-zhi' }]
+    }
   },
   {
     path: 'sso',
@@ -40,32 +54,46 @@ export default [
   {
     path: '/integrations/approval',
     name: 'DMApproval',
-    component: () => import(/* webpackChunkName: "ccsystem-approval" */ '@/views/system/approval/index')
+    component: () => import(/* webpackChunkName: "ccsystem-approval" */ '@/views/system/approval/index'),
+    meta: { breadcrumbs: [{ labelKey: 'nav-shen-pi-yin-qing' }] }
   },
   {
     path: '/integrations/approval/create',
     name: 'DMApprovalCreate',
-    component: () => import(/* webpackChunkName: "ccsystem-approval" */ '@/views/system/approval/form')
+    component: () => import(/* webpackChunkName: "ccsystem-approval" */ '@/views/system/approval/form'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'nav-shen-pi-yin-qing', to: '/integrations/approval' }, { labelKey: 'xin-zeng' }]
+    }
   },
   {
     path: '/integrations/approval/:type/edit',
     name: 'DMApprovalEdit',
-    component: () => import(/* webpackChunkName: "ccsystem-approval" */ '@/views/system/approval/form')
+    component: () => import(/* webpackChunkName: "ccsystem-approval" */ '@/views/system/approval/form'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'nav-shen-pi-yin-qing', to: '/integrations/approval' }, { labelKey: 'pei-zhi' }]
+    }
   },
   {
     path: '/integrations/im',
     name: 'DMIm',
-    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/im')
+    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/im'),
+    meta: { breadcrumbs: [{ labelKey: 'nav-webhook' }] }
   },
   {
     path: '/integrations/im/create',
     name: 'DMImCreate',
-    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/im/form')
+    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/im/form'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'nav-webhook', to: '/integrations/im' }, { labelKey: 'xin-zeng' }]
+    }
   },
   {
     path: '/integrations/im/:imId/edit',
     name: 'DMImEdit',
-    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/im/form')
+    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/im/form'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'nav-webhook', to: '/integrations/im' }, { labelKey: 'bian-ji' }]
+    }
   },
   {
     path: 'im',
@@ -74,12 +102,19 @@ export default [
   {
     path: 'info_center',
     name: 'InfoCenter',
-    component: () => import(/* webpackChunkName: "ticket" */ '@/views/consoleJob/index')
+    component: () => import(/* webpackChunkName: "ticket" */ '@/views/consoleJob/index'),
+    meta: { breadcrumbs: [{ labelKey: 'xiao-xi-zhong-xin' }] }
   },
   {
     path: 'console_job/:id',
     name: 'ConsoleJob/id',
-    component: () => import(/* webpackChunkName: "ticket" */ '@/views/consoleJob/consoleJobDetail')
+    component: () => import(/* webpackChunkName: "ticket" */ '@/views/consoleJob/consoleJobDetail'),
+    meta: {
+      breadcrumbs: [
+        { labelKey: 'xiao-xi-zhong-xin', to: '/system/info_center' },
+        { labelKey: 'ren-wu-xiang-qing', param: 'id' }
+      ]
+    }
   },
   {
     path: '',
@@ -89,7 +124,10 @@ export default [
   {
     path: 'user/config',
     name: 'User_Config',
-    component: () => import(/* webpackChunkName: "ccsystem-home" */ '@/views/system/user/userConfig')
+    component: () => import(/* webpackChunkName: "ccsystem-home" */ '@/views/system/user/userConfig'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'cha-xun-pei-zhi', to: '/datasource' }, { labelKey: 'xiu-gai-can-shu-pei-zhi' }]
+    }
   },
   {
     path: 'role',
@@ -98,30 +136,65 @@ export default [
   {
     path: 'authdm',
     name: 'System_Auth',
-    component: () => import(/* webpackChunkName: "ccsystem-auth" */ '@/views/system/subaccount/auth/authDm')
+    component: () => import(/* webpackChunkName: "ccsystem-auth" */ '@/views/system/subaccount/auth/authDm'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'nav-zhang-hu', to: '/manager/account' }, { labelKey: 'shou-quan' }]
+    }
   },
   {
     path: '/manager/account/batch_authorization',
     name: 'Management_Accounts_Batch_Authorization',
     component: () => import(/* webpackChunkName: "ccsystem-subaccount-batch-auth" */ '@/views/system/subaccount/BatchAuthorizationPage'),
-    meta: { requiredAuth: 'RDP_AUTH_MANAGE' }
+    meta: {
+      requiredAuth: 'RDP_AUTH_MANAGE',
+      breadcrumbs: [{ labelKey: 'nav-zhang-hu', to: '/manager/account' }, { labelKey: 'pi-liang-shou-quan' }]
+    }
   },
   {
     path: '/manager/account/batch_authorization/permissions',
     name: 'Management_Accounts_Batch_Authorization_Permissions',
     component: () => import(/* webpackChunkName: "ccsystem-subaccount-auth" */ '@/views/system/subaccount/auth/authDm'),
-    meta: { requiredAuth: 'RDP_AUTH_MANAGE' }
+    meta: {
+      requiredAuth: 'RDP_AUTH_MANAGE',
+      breadcrumbs: [
+        { labelKey: 'nav-zhang-hu', to: '/manager/account' },
+        {
+          labelKey: 'pi-liang-shou-quan',
+          to: (route) => ({
+            path: '/manager/account/batch_authorization',
+            query: { operation: route.query.operation, uids: route.query.uids }
+          })
+        },
+        { labelKey: 'xuan-ze-quan-xian' }
+      ]
+    }
   },
   {
     path: 'account/authdm/batch',
     name: 'System_Sub_Account_Batch_AuthDm',
     component: () => import(/* webpackChunkName: "ccsystem-subaccount-auth" */ '@/views/system/subaccount/auth/authDm'),
-    meta: { requiredAuth: 'RDP_AUTH_MANAGE' }
+    meta: {
+      requiredAuth: 'RDP_AUTH_MANAGE',
+      breadcrumbs: [
+        { labelKey: 'nav-zhang-hu', to: '/manager/account' },
+        {
+          labelKey: 'pi-liang-shou-quan',
+          to: (route) => ({
+            path: '/manager/account/batch_authorization',
+            query: { operation: route.query.operation, uids: route.query.uids }
+          })
+        },
+        { labelKey: 'xuan-ze-quan-xian' }
+      ]
+    }
   },
   {
     path: 'account/authdm/:uid',
     name: 'System_Sub_Account_AuthDm',
-    component: () => import(/* webpackChunkName: "ccsystem-subaccount-auth" */ '@/views/system/subaccount/auth/authDm')
+    component: () => import(/* webpackChunkName: "ccsystem-subaccount-auth" */ '@/views/system/subaccount/auth/authDm'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'nav-zhang-hu', to: '/manager/account' }, { labelKey: 'shou-quan' }]
+    }
   },
   {
     path: 'account',
@@ -146,31 +219,41 @@ export default [
   {
     path: '/manager/account',
     name: 'Management_Accounts_Account',
-    component: () => import(/* webpackChunkName: "ccsystem-subaccount" */ '@/views/system/subaccount/index')
+    component: () => import(/* webpackChunkName: "ccsystem-subaccount" */ '@/views/system/subaccount/index'),
+    meta: { breadcrumbs: [{ labelKey: 'nav-zhang-hu' }] }
   },
   {
     path: '/manager/role/create',
     name: 'Management_Role_Create',
     component: () => import(/* webpackChunkName: "ccsystem-role" */ '@/views/system/role/RoleEditorPage'),
-    meta: { requiredAuth: 'RDP_ROLE_MANAGE' }
+    meta: {
+      requiredAuth: 'RDP_ROLE_MANAGE',
+      breadcrumbs: [{ labelKey: 'jiao-se', to: '/manager/role' }, { labelKey: 'chuang-jian-jiao-se' }]
+    }
   },
   {
     path: '/manager/role/:roleId/edit',
     name: 'Management_Role_Edit',
     component: () => import(/* webpackChunkName: "ccsystem-role" */ '@/views/system/role/RoleEditorPage'),
-    meta: { requiredAuth: 'RDP_ROLE_MANAGE' }
+    meta: {
+      requiredAuth: 'RDP_ROLE_MANAGE',
+      breadcrumbs: [{ labelKey: 'jiao-se', to: '/manager/role' }, { labelKey: 'bian-ji-jue-se' }]
+    }
   },
   {
     path: '/manager/role/:roleId/view',
     name: 'Management_Role_View',
     component: () => import(/* webpackChunkName: "ccsystem-role" */ '@/views/system/role/RoleEditorPage'),
-    meta: { requiredAuth: 'RDP_ROLE_READ' }
+    meta: {
+      requiredAuth: 'RDP_ROLE_READ',
+      breadcrumbs: [{ labelKey: 'jiao-se', to: '/manager/role' }, { labelKey: 'cha-kan-jue-se' }]
+    }
   },
   {
     path: '/manager/role',
     name: 'Management_Role',
     component: () => import(/* webpackChunkName: "ccsystem-role" */ '@/views/system/role/index'),
-    meta: { requiredAuth: 'RDP_ROLE_READ' }
+    meta: { requiredAuth: 'RDP_ROLE_READ', breadcrumbs: [{ labelKey: 'jiao-se' }] }
   },
   {
     path: 'management/logs',
@@ -205,7 +288,8 @@ export default [
   {
     path: '/env',
     name: 'System_Env',
-    component: () => import(/* webpackChunkName: "ccsystem-env" */ '@/views/system/env')
+    component: () => import(/* webpackChunkName: "ccsystem-env" */ '@/views/system/env'),
+    meta: { breadcrumbs: [{ labelKey: 'huan-jing' }] }
   },
   {
     path: 'env',
@@ -215,7 +299,7 @@ export default [
     path: '/datasource',
     name: 'System_DataSource',
     component: () => import(/* webpackChunkName: "system-datasource" */ '@/views/dataSource/DataSource'),
-    meta: { requiredAuth: 'RDP_DS_READ' }
+    meta: { requiredAuth: 'RDP_DS_READ', breadcrumbs: [{ labelKey: 'nav-shu-ju-ku-guan-li' }] }
   },
   {
     path: 'ccdatasource',
@@ -225,7 +309,7 @@ export default [
     path: '/datasource/add',
     name: 'System_DataSource_Add',
     component: () => import(/* webpackChunkName: "system-datasource" */ '@/views/dataSource/AddDataSource'),
-    meta: { requiredAuth: 'RDP_DS_READ' }
+    meta: { requiredAuth: 'RDP_DS_READ', breadcrumbType: 'datasource-form' }
   },
   {
     path: 'ccdatasource/add',
@@ -234,7 +318,8 @@ export default [
   {
     path: '/data-access/cluster',
     name: 'System_Machine',
-    component: () => import(/* webpackChunkName: "ccsystem-cluster" */ '@/views/worker/Cluster')
+    component: () => import(/* webpackChunkName: "ccsystem-cluster" */ '@/views/worker/Cluster'),
+    meta: { breadcrumbs: [{ labelKey: 'nav-cha-xun-ji-qi-lie-biao' }] }
   },
   {
     path: 'dmmachine',
@@ -243,7 +328,10 @@ export default [
   {
     path: '/data-access/cluster/list/:clusterId',
     name: 'System_Machine_List',
-    component: () => import(/* webpackChunkName: "ccsystem-cluster-list" */ '@/views/system/cluster/workerList')
+    component: () => import(/* webpackChunkName: "ccsystem-cluster-list" */ '@/views/system/cluster/workerList'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'nav-cha-xun-ji-qi-lie-biao', to: '/data-access/cluster' }, { labelKey: 'ji-qi-lie-biao' }]
+    }
   },
   {
     path: 'dmmachine/list/:clusterId',
@@ -252,7 +340,8 @@ export default [
   {
     path: '/data-access/rules',
     name: 'DMRuleList',
-    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/security/index')
+    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/security/index'),
+    meta: { breadcrumbs: [{ labelKey: 'an-quan-gui-fan' }] }
   },
   {
     path: 'dmrulelist',
@@ -261,7 +350,13 @@ export default [
   {
     path: '/data-access/rules/create',
     name: 'DMRuleCreate',
-    component: () => import('@/views/security/rule/ruleDetail')
+    component: () => import('@/views/security/rule/ruleDetail'),
+    meta: {
+      breadcrumbs: [
+        { labelKey: 'an-quan-gui-fan', to: { path: '/data-access/rules', query: { tab: 'template' } } },
+        { labelKey: 'xin-jian-gui-ze-mo-ban' }
+      ]
+    }
   },
   {
     path: 'dmrule/create',
@@ -270,7 +365,13 @@ export default [
   {
     path: '/data-access/rules/detail/:id',
     name: 'DMRuleDetail',
-    component: () => import('@/views/security/rule/ruleDetail')
+    component: () => import('@/views/security/rule/ruleDetail'),
+    meta: {
+      breadcrumbs: [
+        { labelKey: 'an-quan-gui-fan', to: { path: '/data-access/rules', query: { tab: 'template' } } },
+        { labelKey: 'gui-ze-mo-ban-xiang-qing', param: 'id' }
+      ]
+    }
   },
   {
     path: 'dmrule/detail/:id',
@@ -290,37 +391,79 @@ export default [
   {
     path: 'dmspec/:specId',
     name: 'DMSpecDetail',
-    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/security/spec/specDetail')
+    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/security/spec/specDetail'),
+    meta: {
+      breadcrumbs: [
+        { labelKey: 'an-quan-gui-fan', to: { path: '/data-access/rules', query: { tab: 'security' } } },
+        { labelKey: 'gui-ze-xiang-qing', param: 'specId' }
+      ]
+    }
   },
   {
     path: 'dmspec/:specId/rule/:ruleId/range',
     name: 'DMSpecDetailRuleRange',
-    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/security/spec/ruleRange')
+    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/security/spec/ruleRange'),
+    meta: {
+      breadcrumbs: [
+        { labelKey: 'an-quan-gui-fan', to: { path: '/data-access/rules', query: { tab: 'security' } } },
+        {
+          labelKey: 'gui-ze-xiang-qing',
+          param: 'specId',
+          to: (route) => ({
+            path: `/system/dmspec/${route.params.specId}`,
+            query: route.query.ruleKind ? { ruleKind: route.query.ruleKind } : {}
+          })
+        },
+        { labelKey: 'gui-ze-fan-wei' }
+      ]
+    }
   },
   {
     path: 'dmspec/:specId/rule/:ruleId/detail',
     name: 'DMSpecDetailRuleDetail',
-    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/security/spec/ruleDetail')
+    component: () => import(/* webpackChunkName: "ccsystem-datasource" */ '@/views/security/spec/ruleDetail'),
+    meta: {
+      breadcrumbs: [
+        { labelKey: 'an-quan-gui-fan', to: { path: '/data-access/rules', query: { tab: 'security' } } },
+        {
+          labelKey: 'gui-ze-xiang-qing',
+          param: 'specId',
+          to: (route) => ({
+            path: `/system/dmspec/${route.params.specId}`,
+            query: route.query.ruleKind ? { ruleKind: route.query.ruleKind } : {}
+          })
+        },
+        { labelKey: 'gui-ze-xiang-qing', queryLabel: 'ruleName' }
+      ]
+    }
   },
   {
     path: 'desensitization',
     name: 'System_Desensitization',
-    component: () => import(/* webpackChunkName: "ccsystem-desensitization" */ '@/views/system/desensitization/index')
+    component: () => import(/* webpackChunkName: "ccsystem-desensitization" */ '@/views/system/desensitization/index'),
+    meta: { breadcrumbs: [{ labelKey: 'shu-ju-tuo-min' }] }
   },
   {
     path: 'desensitization/add',
     name: 'System_Desensitization_Add',
-    component: () => import(/* webpackChunkName: "ccsystem-desensitization" */ '@/views/system/desensitization/addDesensitization')
+    component: () => import(/* webpackChunkName: "ccsystem-desensitization" */ '@/views/system/desensitization/addDesensitization'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'shu-ju-tuo-min', to: '/system/desensitization' }, { labelKey: 'xin-zeng-tuo-min-ce-lve' }]
+    }
   },
   {
     path: 'data_rules',
     name: 'System_Data_Rules',
-    component: () => import(/* webpackChunkName: "ccsystem-data-rules" */ '@/views/system/dataRule/index')
+    component: () => import(/* webpackChunkName: "ccsystem-data-rules" */ '@/views/system/dataRule/index'),
+    meta: { breadcrumbs: [{ labelKey: 'shu-ju-chu-li-gui-ze-guan-li' }] }
   },
   {
     path: 'data_rules/add',
     name: 'System_Data_Rules_Add',
-    component: () => import(/* webpackChunkName: "ccsystem-data-rules-add" */ '@/views/system/dataRule/addDataRule')
+    component: () => import(/* webpackChunkName: "ccsystem-data-rules-add" */ '@/views/system/dataRule/addDataRule'),
+    meta: {
+      breadcrumbs: [{ labelKey: 'shu-ju-chu-li-gui-ze-guan-li', to: '/system/data_rules' }, { labelKey: 'xin-zeng-gui-ze' }]
+    }
   },
   {
     path: 'data_code',
@@ -340,7 +483,8 @@ export default [
   {
     path: '/settings/profile',
     name: 'Profile',
-    component: () => import(/* webpackChunkName: "ccsystem-env" */ '@/views/system/UserCenter')
+    component: () => import(/* webpackChunkName: "ccsystem-env" */ '@/views/system/UserCenter'),
+    meta: { breadcrumbs: [{ labelKey: 'ge-ren-zi-liao' }] }
   },
   {
     path: 'profile',

--- a/frontend/src/views/consoleJob/consoleJobDetail.vue
+++ b/frontend/src/views/consoleJob/consoleJobDetail.vue
@@ -1,11 +1,5 @@
 <template>
   <div class="console-job-detail-wrapper">
-    <a-breadcrumb style="margin-bottom: 14px">
-      <a-breadcrumb-item>
-        <a href="/#/system/info_center">{{ $t('xiao-xi-zhong-xin') }}</a>
-      </a-breadcrumb-item>
-      <a-breadcrumb-item>{{ $t('xiang-qing') }}</a-breadcrumb-item>
-    </a-breadcrumb>
     <div class="console-job-detail-container">
       <div class="console-job-detail-title">
         <span class="console-job-detail-label">{{ $t('yi-bu-ren-wu-ming-cheng') }}:</span>

--- a/frontend/src/views/consoleJob/index.vue
+++ b/frontend/src/views/consoleJob/index.vue
@@ -1,8 +1,5 @@
 <template>
   <div class="console-job-wrapper" style="padding: 16px">
-    <a-breadcrumb style="margin-bottom: 14px">
-      <a-breadcrumb-item>{{ $t('xiao-xi-zhong-xin') }}</a-breadcrumb-item>
-    </a-breadcrumb>
     <div class="page-header-container border-radius-card">
       <a-form style="padding-right: 300px" layout="inline">
         <a-form-item>

--- a/frontend/src/views/system/dataRule/addDataRule.vue
+++ b/frontend/src/views/system/dataRule/addDataRule.vue
@@ -1,13 +1,5 @@
 <template>
   <div class="add-data-rule">
-    <a-breadcrumb>
-      <a-breadcrumb-item>
-        <router-link :to="{ name: 'System_Data_Rules' }">
-          {{ $t('shu-ju-chu-li-gui-ze-guan-li') }}
-        </router-link>
-      </a-breadcrumb-item>
-      <a-breadcrumb-item>{{ $t('xin-zeng-gui-ze') }}</a-breadcrumb-item>
-    </a-breadcrumb>
     <div class="content">
       <cc-table-tree-select :get-columns="getColumns" :nums="modifiedTableNumObj" :check-errors="checkRuleExpr" />
       <div class="columns">

--- a/frontend/src/views/system/datasource/steps/index.vue
+++ b/frontend/src/views/system/datasource/steps/index.vue
@@ -1,11 +1,5 @@
 <template>
   <div class="add-datasource-steps">
-    <a-breadcrumb style="margin-bottom: 20px">
-      <a-breadcrumb-item>
-        <a href="/#/datasource">{{ $t('shu-ju-yuan-guan-li') }}</a>
-      </a-breadcrumb-item>
-      <a-breadcrumb-item>{{ $t('xin-zeng-shu-ju-yuan') }}</a-breadcrumb-item>
-    </a-breadcrumb>
     <div v-if="step !== 1" class="info">
       <section>
         <div>{{ $t('bu-shu-lei-xing') }}</div>

--- a/frontend/src/views/system/desensitization/addDesensitization.vue
+++ b/frontend/src/views/system/desensitization/addDesensitization.vue
@@ -1,13 +1,5 @@
 <template>
   <div class="add-desensitization">
-    <a-breadcrumb>
-      <a-breadcrumb-item>
-        <router-link :to="{ name: 'System_Desensitization' }">
-          {{ $t('shu-ju-tuo-min') }}
-        </router-link>
-      </a-breadcrumb-item>
-      <a-breadcrumb-item>{{ $t('xin-zeng-tuo-min-ce-lve') }}</a-breadcrumb-item>
-    </a-breadcrumb>
     <div class="tip">
       <b>{{ $t('ban-zhe-yan-tuo-min-can-shu-ge-shi') }}:</b>
       {{ $t('36-biao-shi-di-3456-wei-zhe-yan-5-biao-shi-zui-hou-5-wei-zhe-yan-geng-duo-can-shu-ge-shi-can-kao') }}

--- a/frontend/src/views/system/user/components/Params.vue
+++ b/frontend/src/views/system/user/components/Params.vue
@@ -2,12 +2,6 @@
   <div class="param-list">
     <div class="table-list-layout">
       <div class="table-list">
-        <div class="header">
-          <Breadcrumb>
-            <BreadcrumbItem to="/datasource">{{ $t('cha-xun-pei-zhi') }}</BreadcrumbItem>
-            <BreadcrumbItem>{{ $t('xiu-gai-can-shu-pei-zhi') }}</BreadcrumbItem>
-          </Breadcrumb>
-        </div>
         <DmDsParamsPanel :data-source-id="dataSourceId" />
       </div>
     </div>

--- a/frontend/src/views/worker/Worker.vue
+++ b/frontend/src/views/worker/Worker.vue
@@ -9,10 +9,6 @@
       :handle-confirm="handleConfirmDeleteCluster"
       :handle-close="handleCancelUpdateAlarm"
     />
-    <Breadcrumb>
-      <BreadcrumbItem to="/ccsystem/resource">{{ $t('tong-bu-ji-qi') }}</BreadcrumbItem>
-      <BreadcrumbItem>{{ $t('ji-qi-lie-biao') }}</BreadcrumbItem>
-    </Breadcrumb>
     <div class="worker-list-content">
       <div class="job-header border-radius-card-top">
         <span class="job-header-db">


### PR DESCRIPTION
## Summary

Move page breadcrumb definitions from a large path-matching block in `AppContentHeader` to the route records that own each page.

This keeps navigation metadata next to route definitions, removes duplicate page-local breadcrumbs, preserves current CICD/ticket routes, and makes long breadcrumb trails responsive on narrow screens.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Define breadcrumb labels, links, route params, query labels, and dynamic targets in route metadata.
- Simplify `AppContentHeader` to render route metadata with a page-title fallback.
- Keep datasource creation breadcrumbs dynamic through a dedicated route metadata type.
- Remove duplicate breadcrumbs from message-center, datasource, rule, desensitization, user-parameter, and worker pages.
- Collapse long breadcrumb trails to the previous and current entries on narrow screens.

## Test Plan

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [x] Frontend lint / build
- [ ] Backend build
- [ ] Manual verification

Details:

```text
npm run lint
npm run build
Verified all 42 route labelKey values exist in both en.json and zh.json.
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [ ] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
