### PR TITLE
fix(frontend): open SQL console in a new tab

### DIFF
--- a/frontend/src/components/GoDmButton.vue
+++ b/frontend/src/components/GoDmButton.vue
@@ -12,7 +12,7 @@ export default {
   methods: {
     handleGoDmConsole() {
       if (this.includesDM) {
-        this.$router.push({ path: '/sql' });
+        window.open(this.$router.resolve({ path: '/sql' }).href, '_blank', 'noopener');
       } else {
         this.$Modal.warning({
           title: this.$t('cao-zuo-ti-shi'),

--- a/frontend/src/components/layout/AppContentHeader.vue
+++ b/frontend/src/components/layout/AppContentHeader.vue
@@ -28,7 +28,7 @@
       </h1>
     </div>
     <div class="app-content-header__right">
-      <a v-if="showSqlLink" href="/#/sql" class="app-content-header__link" @click.prevent="handleGoSql">
+      <a v-if="showSqlLink" :href="sqlConsoleHref" class="app-content-header__link" target="_blank" rel="noopener" @click="handleGoSql">
         <CustomIcon type="icon-v2-SqlLog" size="14px" />
         <span>{{ $t('sql-cha-xun') }}</span>
       </a>
@@ -53,6 +53,9 @@ export default {
     ...mapState(['dmGlobalSetting', 'myCatLog', 'mySystemMenuItems', 'sidebarMenu', 'userInfo']),
     showSqlLink() {
       return this.includesDM && this.myCatLog.includes('CAT_DM_CONSOLE') && !this.$route.path.startsWith('/sql');
+    },
+    sqlConsoleHref() {
+      return this.$router.resolve({ path: '/sql' }).href;
     },
     pageTitle() {
       const path = this.$route.path;
@@ -386,7 +389,6 @@ export default {
   methods: {
     handleGoSql() {
       saveLastWorkbenchRoute(this.$route, this.userInfo?.uid);
-      this.$router.push({ path: '/sql' }).catch(() => {});
     },
     handleBreadcrumbEvent(eventName) {
       if (!eventName) {


### PR DESCRIPTION
## Summary

Open the SQL console in a new browser tab instead of replacing the page the user is currently working on.

Previously, clicking a SQL console entry from a ticket or configuration page navigated the current browser tab to `/sql`. The original page was replaced, so users had to navigate back before continuing their work.

After this change, the SQL console opens in a separate tab and the original page remains open and unchanged.

## User-visible behavior

- The DM console button opens `/sql` in a new tab.
- The SQL query link in the page header opens `/sql` in a new tab.
- The current ticket or configuration page stays open in the original tab.
- The header entry continues to save `lastWorkbenchRoute` before opening SQL.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Resolve the SQL console URL through Vue Router.
- Use standard `target="_blank"` and `rel="noopener"` link behavior in the page header.
- Stop replacing the current route when SQL is opened.
- Preserve the existing last-workbench-route state.

## Test Plan

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [x] Frontend lint / build
- [ ] Backend build
- [ ] Manual verification

Details:

```text
npx eslint src/components/GoDmButton.vue src/components/layout/AppContentHeader.vue
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [ ] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
