### PR TITLE
feat(sql): add prior-backup analysis for MySQL and PostgreSQL

### DIFF
--- a/backend/clouddm-platform/cgdm-plugin-sdk/src/main/java/com/clougence/clouddm/sdk/sql/SqlEngineSpi.java
+++ b/backend/clouddm-platform/cgdm-plugin-sdk/src/main/java/com/clougence/clouddm/sdk/sql/SqlEngineSpi.java
@@ -19,6 +19,7 @@ import com.clougence.clouddm.sdk.Spi;
 import com.clougence.clouddm.sdk.sql.analysis.behavior.BehaviorAnalysisSpi;
 import com.clougence.clouddm.sdk.sql.analysis.lineage.LineageAnalysisSpi;
 import com.clougence.clouddm.sdk.sql.analysis.security.SecDomainResolveSpi;
+import com.clougence.clouddm.sdk.sql.backup.PriorBackupSpi;
 import com.clougence.clouddm.sdk.sql.editor.rewrite.RewriteSpi;
 import com.clougence.clouddm.sdk.sql.parser.SplitAnalysisSpi;
 import com.clougence.dslpaser.antlr.DslProvider;
@@ -73,4 +74,16 @@ public interface SqlEngineSpi extends Spi {
      * @param parameters parser parameters, or null/empty to use implementation defaults.
      */
     RewriteSpi rewriteSpi(SqlParserParameters parameters);
+
+    // backup
+
+    /**
+     * Returns the prior-backup analysis SPI, or null if row-level backup before UPDATE/DELETE is
+     * not supported by this engine.
+     *
+     * @param parameters parser parameters, or null/empty to use implementation defaults.
+     */
+    default PriorBackupSpi priorBackupSpi(SqlParserParameters parameters) {
+        return null;
+    }
 }

--- a/backend/clouddm-platform/cgdm-plugin-sdk/src/main/java/com/clougence/clouddm/sdk/sql/backup/BackupStatement.java
+++ b/backend/clouddm-platform/cgdm-plugin-sdk/src/main/java/com/clougence/clouddm/sdk/sql/backup/BackupStatement.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.clougence.clouddm.sdk.sql.backup;
+
+import com.clougence.clouddm.sdk.sql.parser.SplitQueryType;
+
+/**
+ * Prior-backup analysis result for a single UPDATE/DELETE statement.
+ * Carries the facts needed to build a row-level backup (CTAS) before the change runs
+ * and to generate the rollback SQL after the change completes.
+ */
+public class BackupStatement {
+
+    /** statement type, only UPDATE or DELETE. */
+    private SplitQueryType statementType;
+
+    /** target table text as written in the statement, schema prefix kept if present. */
+    private String         sourceTable;
+
+    /** dialect-correct query selecting the affected rows, e.g. {@code SELECT * FROM t WHERE ...}. */
+    private String         selectSql;
+
+    /** whether the statement carries a WHERE clause; full-table changes are backed up by policy of the caller. */
+    private boolean        hasWhere;
+
+    public SplitQueryType getStatementType() {
+        return statementType;
+    }
+
+    public void setStatementType(SplitQueryType statementType) {
+        this.statementType = statementType;
+    }
+
+    public String getSourceTable() {
+        return sourceTable;
+    }
+
+    public void setSourceTable(String sourceTable) {
+        this.sourceTable = sourceTable;
+    }
+
+    public String getSelectSql() {
+        return selectSql;
+    }
+
+    public void setSelectSql(String selectSql) {
+        this.selectSql = selectSql;
+    }
+
+    public boolean isHasWhere() {
+        return hasWhere;
+    }
+
+    public void setHasWhere(boolean hasWhere) {
+        this.hasWhere = hasWhere;
+    }
+}

--- a/backend/clouddm-platform/cgdm-plugin-sdk/src/main/java/com/clougence/clouddm/sdk/sql/backup/PriorBackupSpi.java
+++ b/backend/clouddm-platform/cgdm-plugin-sdk/src/main/java/com/clougence/clouddm/sdk/sql/backup/PriorBackupSpi.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.clougence.clouddm.sdk.sql.backup;
+
+import com.clougence.clouddm.sdk.Spi;
+
+/**
+ * Analyzes a single UPDATE/DELETE statement for the prior-backup feature.
+ *
+ * <p>Implementations parse the statement with the dialect parser and report the target table and
+ * the affected-row query. Statements that are not a plain single-table UPDATE/DELETE (CTE, multi
+ * table update, USING clause, RETURNING, or any parse failure) must return {@code null} so the
+ * caller can skip the backup without blocking the ticket.</p>
+ */
+public interface PriorBackupSpi extends Spi {
+
+    /**
+     * Analyzes one statement and returns the backup facts, or {@code null} if the statement is not
+     * eligible for automatic row-level backup.
+     *
+     * @param query a single UPDATE or DELETE statement.
+     */
+    BackupStatement analysisBackup(String query);
+
+    /**
+     * Generates the reverse statement for a structural DDL, or {@code null} when no lossless
+     * reverse exists. Only additive/renaming DDL should be reversed (CREATE TABLE → DROP TABLE,
+     * CREATE INDEX → DROP INDEX, ADD COLUMN → DROP COLUMN, RENAME → reverse RENAME); destructive
+     * DDL (DROP/TRUNCATE) loses data and must return {@code null}.
+     *
+     * @param query a single DDL statement.
+     */
+    default String reverseDdl(String query) {
+        return null;
+    }
+}

--- a/backend/clouddm-plugins/clouddm-sql/sql-mysql/src/main/java/com/clougence/sql/mysql/MySqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mysql/src/main/java/com/clougence/sql/mysql/MySqlEngineSpi.java
@@ -27,9 +27,11 @@ import com.clougence.clouddm.sdk.sql.SqlParserParameters;
 import com.clougence.clouddm.sdk.sql.analysis.behavior.BehaviorAnalysisSpi;
 import com.clougence.clouddm.sdk.sql.analysis.lineage.LineageAnalysisSpi;
 import com.clougence.clouddm.sdk.sql.analysis.security.SecDomainResolveSpi;
+import com.clougence.clouddm.sdk.sql.backup.PriorBackupSpi;
 import com.clougence.clouddm.sdk.sql.editor.rewrite.RewriteSpi;
 import com.clougence.clouddm.sdk.sql.parser.SplitAnalysisSpi;
 import com.clougence.dslpaser.antlr.DslProvider;
+import com.clougence.sql.mysql.analysis.backup.MyPriorBackupSpi;
 import com.clougence.sql.mysql.analysis.behavior.MyBehaviorAnalysisSpi;
 import com.clougence.sql.mysql.analysis.lineage.MyLineageAnalysisSpi;
 import com.clougence.sql.mysql.analysis.security.MySecDomainResolveSpi;
@@ -49,6 +51,7 @@ public class MySqlEngineSpi implements SqlEngineSpi {
     private final Map<String, BehaviorAnalysisSpi> behaviorCache  = new ConcurrentHashMap<>();
     private final Map<String, LineageAnalysisSpi>  lineageCache   = new ConcurrentHashMap<>();
     private final Map<String, RewriteSpi>          rewriteCache   = new ConcurrentHashMap<>();
+    private final Map<String, PriorBackupSpi>      backupCache    = new ConcurrentHashMap<>();
     private final Map<String, DslProvider>         dslCache       = new ConcurrentHashMap<>();
 
     public MySqlEngineSpi(MetaService metaService){
@@ -138,6 +141,13 @@ public class MySqlEngineSpi implements SqlEngineSpi {
         SqlParserParameters parserParameters = SqlParserParameters.nullToEmpty(parameters);
         String key = parserKey(parserParameters);
         return lineageCache.computeIfAbsent(key, value -> new MyLineageAnalysisSpi(metaService, parserConfig(parserParameters)));
+    }
+
+    @Override
+    public PriorBackupSpi priorBackupSpi(SqlParserParameters parameters) {
+        SqlParserParameters parserParameters = SqlParserParameters.nullToEmpty(parameters);
+        String key = parserKey(parserParameters);
+        return backupCache.computeIfAbsent(key, value -> new MyPriorBackupSpi(parserConfig(parserParameters)));
     }
 
     @Override

--- a/backend/clouddm-plugins/clouddm-sql/sql-mysql/src/main/java/com/clougence/sql/mysql/analysis/backup/MyPriorBackupSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mysql/src/main/java/com/clougence/sql/mysql/analysis/backup/MyPriorBackupSpi.java
@@ -34,9 +34,10 @@ import com.clougence.sql.mysql.parser.MySqlParserConfig;
 import com.clougence.sql.mysql.parser.antlr.MySqlParser;
 
 /**
- * MySQL 方言的 prior backup 解析：与 PG 版语义对齐。
- * 备份仅覆盖纯单表 UPDATE/DELETE；多表变更、CTE、ORDER BY/LIMIT（影响行集与备份 SELECT 不保证一致）、
- * PARTITION 子句形态一律返回 null 跳过。DDL 逆语句覆盖建表/建索引/加列。
+ * Prior-backup analysis for the MySQL dialect, aligned with the PostgreSQL implementation.
+ * Backups cover only simple, single-table UPDATE and DELETE statements. Multi-table changes,
+ * CTEs, ORDER BY/LIMIT clauses, and PARTITION clauses return {@code null}. Reverse DDL covers
+ * table creation, index creation, and column addition.
  */
 public class MyPriorBackupSpi implements PriorBackupSpi {
 
@@ -68,12 +69,12 @@ public class MyPriorBackupSpi implements PriorBackupSpi {
     }
 
     private BackupStatement analysisUpdate(MySqlParser.UpdateStatementContext ctx) {
-        // 多表 UPDATE 无法用单一 SELECT 备份，跳过
+        // A multi-table UPDATE cannot be backed up with a single SELECT.
         MySqlParser.SingleUpdateStatementContext single = ctx.singleUpdateStatement();
         if (single == null) {
             return null;
         }
-        // CTE、PARTITION、ORDER BY、LIMIT 形态的受影响行集与备份 SELECT 不保证一致，跳过
+        // These clauses may make the backup SELECT target a different row set.
         if (single.withClause() != null || single.uidList() != null || single.orderByClause() != null || single.limitClause() != null) {
             return null;
         }
@@ -132,8 +133,8 @@ public class MyPriorBackupSpi implements PriorBackupSpi {
     }
 
     private String reverseCreateTable(MySqlParser.CreateTableContext ctx) {
-        // 三种建表形态（常规/CTAS/LIKE 复制）都建出了新表，逆操作统一 DROP；
-        // IF NOT EXISTS 语义下表可能本来就存在，逆向 DROP 会误删旧表，跳过
+        // All three forms (regular, CTAS, and LIKE) create a table, so their reverse operation is DROP.
+        // Skip IF NOT EXISTS because the table may have existed before the statement.
         if (ctx instanceof MySqlParser.ColumnCreateTableContext) {
             MySqlParser.ColumnCreateTableContext create = (MySqlParser.ColumnCreateTableContext) ctx;
             return create.ifNotExists() != null ? null : "DROP TABLE " + originalText(create.tableName()) + ";";
@@ -147,7 +148,7 @@ public class MyPriorBackupSpi implements PriorBackupSpi {
             if (create.ifNotExists() != null) {
                 return null;
             }
-            // LIKE 复制形态有两个 tableName，文法顺序第一个是新建的表
+            // The LIKE form has two table names; the grammar lists the newly created table first.
             List<MySqlParser.TableNameContext> names = create.tableName();
             if (names == null || names.isEmpty()) {
                 return null;
@@ -161,12 +162,12 @@ public class MyPriorBackupSpi implements PriorBackupSpi {
         if (ctx.indexName() == null || ctx.tableName() == null) {
             return null;
         }
-        // MySQL 删索引语法要求带表名
+        // MySQL requires the table name when dropping an index.
         return "DROP INDEX " + originalText(ctx.indexName()) + " ON " + originalText(ctx.tableName()) + ";";
     }
 
     private String reverseAlterTable(MySqlParser.AlterTableContext ctx) {
-        // 只逆向"全部子命令都是 ADD COLUMN"的 ALTER，混入其他操作时整条放弃
+        // Reverse only ALTER statements whose subcommands are all ADD COLUMN operations.
         if (ctx.tableName() == null || ctx.alterSpecification() == null || ctx.alterSpecification().isEmpty()) {
             return null;
         }
@@ -192,7 +193,7 @@ public class MyPriorBackupSpi implements PriorBackupSpi {
         return String.join("\n", dropColumns);
     }
 
-    /** 解析并要求恰好一条语句，返回其 SqlStatementContext；解析失败或多条返回 null */
+    /** Parses exactly one statement and returns {@code null} on failure or multiple statements. */
     private MySqlParser.SqlStatementContext parseSingle(String query) {
         List<AstSplitScript> scripts;
         try {
@@ -210,7 +211,7 @@ public class MyPriorBackupSpi implements PriorBackupSpi {
         return (MySqlParser.SqlStatementContext) astTree;
     }
 
-    /** 从原始输入流取 ctx 的原文，保留大小写、引号和内部空白 */
+    /** Returns the original source text while preserving case, quoting, and internal whitespace. */
     private String originalText(ParserRuleContext ctx) {
         return ctx.start.getInputStream().getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
     }

--- a/backend/clouddm-plugins/clouddm-sql/sql-mysql/src/main/java/com/clougence/sql/mysql/analysis/backup/MyPriorBackupSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mysql/src/main/java/com/clougence/sql/mysql/analysis/backup/MyPriorBackupSpi.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.clougence.sql.mysql.analysis.backup;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.tree.ParseTree;
+
+import com.clougence.clouddm.sdk.sql.backup.BackupStatement;
+import com.clougence.clouddm.sdk.sql.backup.PriorBackupSpi;
+import com.clougence.clouddm.sdk.sql.parser.SplitQueryType;
+import com.clougence.dslpaser.antlr.DslHelper;
+import com.clougence.dslpaser.parse.AstSplitScript;
+import com.clougence.sql.mysql.parser.MyDslProvider;
+import com.clougence.sql.mysql.parser.MySqlParserConfig;
+import com.clougence.sql.mysql.parser.antlr.MySqlParser;
+
+/**
+ * MySQL 方言的 prior backup 解析：与 PG 版语义对齐。
+ * 备份仅覆盖纯单表 UPDATE/DELETE；多表变更、CTE、ORDER BY/LIMIT（影响行集与备份 SELECT 不保证一致）、
+ * PARTITION 子句形态一律返回 null 跳过。DDL 逆语句覆盖建表/建索引/加列。
+ */
+public class MyPriorBackupSpi implements PriorBackupSpi {
+
+    private final MyDslProvider provider;
+
+    public MyPriorBackupSpi(MySqlParserConfig config){
+        this.provider = new MyDslProvider(config);
+    }
+
+    @Override
+    public String name() {
+        return "MySQL PriorBackup";
+    }
+
+    @Override
+    public BackupStatement analysisBackup(String query) {
+        MySqlParser.SqlStatementContext stmt = parseSingle(query);
+        MySqlParser.DmlStatementContext dml = stmt != null ? stmt.dmlStatement() : null;
+        if (dml == null) {
+            return null;
+        }
+        if (dml.updateStatement() != null) {
+            return analysisUpdate(dml.updateStatement());
+        }
+        if (dml.deleteStatement() != null) {
+            return analysisDelete(dml.deleteStatement());
+        }
+        return null;
+    }
+
+    private BackupStatement analysisUpdate(MySqlParser.UpdateStatementContext ctx) {
+        // 多表 UPDATE 无法用单一 SELECT 备份，跳过
+        MySqlParser.SingleUpdateStatementContext single = ctx.singleUpdateStatement();
+        if (single == null) {
+            return null;
+        }
+        // CTE、PARTITION、ORDER BY、LIMIT 形态的受影响行集与备份 SELECT 不保证一致，跳过
+        if (single.withClause() != null || single.uidList() != null || single.orderByClause() != null || single.limitClause() != null) {
+            return null;
+        }
+        String tableText = originalText(single.tableName());
+        String aliasText = single.uid() != null ? " " + originalText(single.uid()) : "";
+        return buildStatement(SplitQueryType.UPDATE, tableText, tableText + aliasText, single.whereClause());
+    }
+
+    private BackupStatement analysisDelete(MySqlParser.DeleteStatementContext ctx) {
+        MySqlParser.SingleDeleteStatementContext single = ctx.singleDeleteStatement();
+        if (single == null) {
+            return null;
+        }
+        if (single.withClause() != null || single.uidList() != null || single.orderByClause() != null || single.limitClauseAtom() != null) {
+            return null;
+        }
+        String tableText = originalText(single.tableName());
+        String aliasText = single.deleteTableAlias() != null ? " " + originalText(single.deleteTableAlias()) : "";
+        return buildStatement(SplitQueryType.DELETE, tableText, tableText + aliasText, single.whereClause());
+    }
+
+    private BackupStatement buildStatement(SplitQueryType type, String sourceTable, String fromText, MySqlParser.WhereClauseContext whereCtx) {
+        BackupStatement statement = new BackupStatement();
+        statement.setStatementType(type);
+        statement.setSourceTable(sourceTable);
+        statement.setHasWhere(whereCtx != null);
+        if (whereCtx != null) {
+            statement.setSelectSql("SELECT * FROM " + fromText + " " + originalText(whereCtx));
+        } else {
+            statement.setSelectSql("SELECT * FROM " + fromText);
+        }
+        return statement;
+    }
+
+    @Override
+    public String reverseDdl(String query) {
+        MySqlParser.SqlStatementContext stmt = parseSingle(query);
+        if (stmt == null || stmt.ddlStatement() == null) {
+            return null;
+        }
+        MySqlParser.DdlStatementContext ddl = stmt.ddlStatement();
+        try {
+            if (ddl.createTable() != null) {
+                return reverseCreateTable(ddl.createTable());
+            }
+            if (ddl.createIndex() != null) {
+                return reverseCreateIndex(ddl.createIndex());
+            }
+            if (ddl.alterTable() != null) {
+                return reverseAlterTable(ddl.alterTable());
+            }
+        } catch (Exception e) {
+            return null;
+        }
+        return null;
+    }
+
+    private String reverseCreateTable(MySqlParser.CreateTableContext ctx) {
+        // 三种建表形态（常规/CTAS/LIKE 复制）都建出了新表，逆操作统一 DROP；
+        // IF NOT EXISTS 语义下表可能本来就存在，逆向 DROP 会误删旧表，跳过
+        if (ctx instanceof MySqlParser.ColumnCreateTableContext) {
+            MySqlParser.ColumnCreateTableContext create = (MySqlParser.ColumnCreateTableContext) ctx;
+            return create.ifNotExists() != null ? null : "DROP TABLE " + originalText(create.tableName()) + ";";
+        }
+        if (ctx instanceof MySqlParser.QueryCreateTableContext) {
+            MySqlParser.QueryCreateTableContext create = (MySqlParser.QueryCreateTableContext) ctx;
+            return create.ifNotExists() != null ? null : "DROP TABLE " + originalText(create.tableName()) + ";";
+        }
+        if (ctx instanceof MySqlParser.CopyCreateTableContext) {
+            MySqlParser.CopyCreateTableContext create = (MySqlParser.CopyCreateTableContext) ctx;
+            if (create.ifNotExists() != null) {
+                return null;
+            }
+            // LIKE 复制形态有两个 tableName，文法顺序第一个是新建的表
+            List<MySqlParser.TableNameContext> names = create.tableName();
+            if (names == null || names.isEmpty()) {
+                return null;
+            }
+            return "DROP TABLE " + originalText(names.get(0)) + ";";
+        }
+        return null;
+    }
+
+    private String reverseCreateIndex(MySqlParser.CreateIndexContext ctx) {
+        if (ctx.indexName() == null || ctx.tableName() == null) {
+            return null;
+        }
+        // MySQL 删索引语法要求带表名
+        return "DROP INDEX " + originalText(ctx.indexName()) + " ON " + originalText(ctx.tableName()) + ";";
+    }
+
+    private String reverseAlterTable(MySqlParser.AlterTableContext ctx) {
+        // 只逆向"全部子命令都是 ADD COLUMN"的 ALTER，混入其他操作时整条放弃
+        if (ctx.tableName() == null || ctx.alterSpecification() == null || ctx.alterSpecification().isEmpty()) {
+            return null;
+        }
+        String table = originalText(ctx.tableName());
+        List<String> dropColumns = new ArrayList<>();
+        for (MySqlParser.AlterSpecificationContext spec : ctx.alterSpecification()) {
+            if (spec instanceof MySqlParser.AlterByAddColumnContext) {
+                MySqlParser.AlterByAddColumnContext addColumn = (MySqlParser.AlterByAddColumnContext) spec;
+                dropColumns.add("ALTER TABLE " + table + " DROP COLUMN " + originalText(addColumn.columnDefinition().uid()) + ";");
+            } else if (spec instanceof MySqlParser.AlterByAddColumnsContext) {
+                MySqlParser.AlterByAddColumnsContext addColumns = (MySqlParser.AlterByAddColumnsContext) spec;
+                for (MySqlParser.ColumnDefinitionContext columnDefinition : addColumns.columnDefinition()) {
+                    dropColumns.add("ALTER TABLE " + table + " DROP COLUMN " + originalText(columnDefinition.uid()) + ";");
+                }
+            } else {
+                return null;
+            }
+        }
+        if (dropColumns.isEmpty()) {
+            return null;
+        }
+        Collections.reverse(dropColumns);
+        return String.join("\n", dropColumns);
+    }
+
+    /** 解析并要求恰好一条语句，返回其 SqlStatementContext；解析失败或多条返回 null */
+    private MySqlParser.SqlStatementContext parseSingle(String query) {
+        List<AstSplitScript> scripts;
+        try {
+            scripts = DslHelper.splitDsl(provider, new StringReader(query));
+        } catch (Exception e) {
+            return null;
+        }
+        if (scripts.size() != 1) {
+            return null;
+        }
+        ParseTree astTree = scripts.get(0).getAstTree();
+        if (!(astTree instanceof MySqlParser.SqlStatementContext)) {
+            return null;
+        }
+        return (MySqlParser.SqlStatementContext) astTree;
+    }
+
+    /** 从原始输入流取 ctx 的原文，保留大小写、引号和内部空白 */
+    private String originalText(ParserRuleContext ctx) {
+        return ctx.start.getInputStream().getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+    }
+}

--- a/backend/clouddm-plugins/clouddm-sql/sql-postgres/src/main/java/com/clougence/sql/postgres/PgSqlEngineSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-postgres/src/main/java/com/clougence/sql/postgres/PgSqlEngineSpi.java
@@ -25,9 +25,11 @@ import com.clougence.clouddm.sdk.sql.SqlParserParameters;
 import com.clougence.clouddm.sdk.sql.analysis.behavior.BehaviorAnalysisSpi;
 import com.clougence.clouddm.sdk.sql.analysis.lineage.LineageAnalysisSpi;
 import com.clougence.clouddm.sdk.sql.analysis.security.SecDomainResolveSpi;
+import com.clougence.clouddm.sdk.sql.backup.PriorBackupSpi;
 import com.clougence.clouddm.sdk.sql.editor.rewrite.RewriteSpi;
 import com.clougence.clouddm.sdk.sql.parser.SplitAnalysisSpi;
 import com.clougence.dslpaser.antlr.DslProvider;
+import com.clougence.sql.postgres.analysis.backup.PgPriorBackupSpi;
 import com.clougence.sql.postgres.analysis.behavior.PgBehaviorAnalysisSpi;
 import com.clougence.sql.postgres.analysis.security.PgSecDomainResolveSpi;
 import com.clougence.sql.postgres.editor.rewrite.PgRewriteSpi;
@@ -44,6 +46,7 @@ public class PgSqlEngineSpi implements SqlEngineSpi {
     private final Map<String, SecDomainResolveSpi> secDomainCache = new ConcurrentHashMap<>();
     private final Map<String, BehaviorAnalysisSpi> behaviorCache  = new ConcurrentHashMap<>();
     private final Map<String, RewriteSpi>          rewriteCache   = new ConcurrentHashMap<>();
+    private final Map<String, PriorBackupSpi>      backupCache    = new ConcurrentHashMap<>();
     private final Map<String, DslProvider>         dslCache       = new ConcurrentHashMap<>();
 
     public PgSqlEngineSpi(MetaService metaService){
@@ -101,6 +104,13 @@ public class PgSqlEngineSpi implements SqlEngineSpi {
         SqlParserParameters parserParameters = SqlParserParameters.nullToEmpty(parameters);
         String key = parserKey(parserParameters);
         return rewriteCache.computeIfAbsent(key, value -> new PgRewriteSpi(resolveVersion(parserParameters)));
+    }
+
+    @Override
+    public PriorBackupSpi priorBackupSpi(SqlParserParameters parameters) {
+        SqlParserParameters parserParameters = SqlParserParameters.nullToEmpty(parameters);
+        String key = parserKey(parserParameters);
+        return backupCache.computeIfAbsent(key, value -> new PgPriorBackupSpi(resolveVersion(parserParameters)));
     }
 
 }

--- a/backend/clouddm-plugins/clouddm-sql/sql-postgres/src/main/java/com/clougence/sql/postgres/analysis/backup/PgPriorBackupSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-postgres/src/main/java/com/clougence/sql/postgres/analysis/backup/PgPriorBackupSpi.java
@@ -36,7 +36,7 @@ import com.clougence.sql.postgres.parser.antlr.PgSqlParser;
 
 public class PgPriorBackupSpi implements PriorBackupSpi {
 
-    /** WHERE CURRENT OF cursor 形态无法转成 SELECT，排除备份 */
+    /** WHERE CURRENT OF cannot be converted into a backup SELECT. */
     private static final Pattern WHERE_CURRENT_OF = Pattern.compile("^WHERE\\s+CURRENT\\s+OF\\b", Pattern.CASE_INSENSITIVE);
 
     private final PgDslProvider  provider;
@@ -77,7 +77,7 @@ public class PgPriorBackupSpi implements PriorBackupSpi {
     }
 
     private BackupStatement analysisUpdate(PgSqlParser.UpdatestmtContext ctx) {
-        // CTE、多表 FROM 参照、RETURNING 均不是纯单表变更，跳过备份
+        // CTEs, additional FROM relations, and RETURNING are not simple single-table changes.
         if (ctx.with_clause_() != null || ctx.from_clause() != null || ctx.returning_clause() != null) {
             return null;
         }
@@ -85,7 +85,7 @@ public class PgPriorBackupSpi implements PriorBackupSpi {
     }
 
     private BackupStatement analysisDelete(PgSqlParser.DeletestmtContext ctx) {
-        // CTE、USING 多表、RETURNING 跳过备份
+        // Skip CTEs, multi-table USING clauses, and RETURNING clauses.
         if (ctx.with_clause_() != null || ctx.using_clause() != null || ctx.returning_clause() != null) {
             return null;
         }
@@ -94,7 +94,7 @@ public class PgPriorBackupSpi implements PriorBackupSpi {
 
     private BackupStatement buildStatement(SplitQueryType type, PgSqlParser.Relation_expr_opt_aliasContext relationCtx,
                                            PgSqlParser.Where_or_current_clauseContext whereCtx) {
-        // FROM 片段保留语句里的别名原文，保证 WHERE 中的别名引用在备份 SELECT 中依然成立
+        // Preserve the original alias so references in the WHERE clause remain valid.
         String fromText = originalText(relationCtx);
         String sourceTable = originalText(relationCtx.relation_expr().qualified_name());
 
@@ -151,7 +151,7 @@ public class PgPriorBackupSpi implements PriorBackupSpi {
     }
 
     private String reverseCreateTable(PgSqlParser.CreatestmtContext ctx) {
-        // IF NOT EXISTS 语义下表可能本来就存在，逆向 DROP 会误删旧表，跳过
+        // Skip IF NOT EXISTS because the table may have existed before the statement.
         if (ctx.if_not_exists_() != null) {
             return null;
         }
@@ -163,12 +163,12 @@ public class PgPriorBackupSpi implements PriorBackupSpi {
     }
 
     private String reverseCreateIndex(PgSqlParser.IndexstmtContext ctx) {
-        // 匿名索引名字由数据库生成，无法静态推导；IF NOT EXISTS 同 CREATE TABLE 的顾虑，均跳过
+        // Anonymous index names cannot be inferred, and IF NOT EXISTS may refer to an existing index.
         if (ctx.index_name_() == null || ctx.IF_P() != null) {
             return null;
         }
         String indexName = originalText(ctx.index_name_()).trim();
-        // 索引与表同 schema：表名带 schema 前缀时，DROP INDEX 也补同样前缀
+        // Qualify the index with the table schema when the table name is schema-qualified.
         String schemaPrefix = "";
         if (ctx.relation_expr() != null) {
             String table = originalText(ctx.relation_expr());
@@ -181,15 +181,15 @@ public class PgPriorBackupSpi implements PriorBackupSpi {
     }
 
     private String reverseAlterTable(PgSqlParser.AltertablestmtContext ctx) {
-        // 只逆向"全部子命令都是 ADD COLUMN"的 ALTER：混入其他操作（DROP/ALTER TYPE/ADD CONSTRAINT）时整条放弃
+        // Reverse only ALTER statements whose subcommands are all ADD COLUMN operations.
         if (ctx.relation_expr() == null || ctx.alter_table_cmds() == null) {
             return null;
         }
         String table = originalText(ctx.relation_expr());
         List<String> dropColumns = new ArrayList<>();
         for (PgSqlParser.Alter_table_cmdContext cmd : ctx.alter_table_cmds().alter_table_cmd()) {
-            // 文法按 label 生成子类：只有 ADD [COLUMN]（AddColumnContext）可逆；
-            // IF NOT EXISTS 存在时列可能本来就有，逆向 DROP 会误删旧列，整条放弃
+            // The grammar labels ADD [COLUMN] as AddColumnContext, the only reversible form here.
+            // Skip IF NOT EXISTS because the column may have existed before the statement.
             if (!(cmd instanceof PgSqlParser.AddColumnContext)) {
                 return null;
             }
@@ -206,7 +206,7 @@ public class PgPriorBackupSpi implements PriorBackupSpi {
         return String.join("\n", dropColumns);
     }
 
-    /** 从原始输入流取 ctx 的原文，保留大小写、引号和内部空白 */
+    /** Returns the original source text while preserving case, quoting, and internal whitespace. */
     private String originalText(ParserRuleContext ctx) {
         return ctx.start.getInputStream().getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
     }

--- a/backend/clouddm-plugins/clouddm-sql/sql-postgres/src/main/java/com/clougence/sql/postgres/analysis/backup/PgPriorBackupSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-postgres/src/main/java/com/clougence/sql/postgres/analysis/backup/PgPriorBackupSpi.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.clougence.sql.postgres.analysis.backup;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.tree.ParseTree;
+
+import com.clougence.clouddm.sdk.sql.backup.BackupStatement;
+import com.clougence.clouddm.sdk.sql.backup.PriorBackupSpi;
+import com.clougence.clouddm.sdk.sql.parser.SplitQueryType;
+import com.clougence.dslpaser.antlr.DslHelper;
+import com.clougence.dslpaser.parse.AstSplitScript;
+import com.clougence.sql.postgres.parser.PgDslProvider;
+import com.clougence.sql.postgres.parser.PostgresVersion;
+import com.clougence.sql.postgres.parser.antlr.PgSqlParser;
+
+public class PgPriorBackupSpi implements PriorBackupSpi {
+
+    /** WHERE CURRENT OF cursor 形态无法转成 SELECT，排除备份 */
+    private static final Pattern WHERE_CURRENT_OF = Pattern.compile("^WHERE\\s+CURRENT\\s+OF\\b", Pattern.CASE_INSENSITIVE);
+
+    private final PgDslProvider  provider;
+
+    public PgPriorBackupSpi(PostgresVersion version){
+        this.provider = new PgDslProvider(version);
+    }
+
+    @Override
+    public String name() {
+        return "PG PriorBackup";
+    }
+
+    @Override
+    public BackupStatement analysisBackup(String query) {
+        List<AstSplitScript> scripts;
+        try {
+            scripts = DslHelper.splitDsl(provider, new StringReader(query));
+        } catch (Exception e) {
+            return null;
+        }
+        if (scripts.size() != 1) {
+            return null;
+        }
+
+        ParseTree astTree = scripts.get(0).getAstTree();
+        if (!(astTree instanceof PgSqlParser.StmtContext)) {
+            return null;
+        }
+        PgSqlParser.StmtContext stmt = (PgSqlParser.StmtContext) astTree;
+        if (stmt.updatestmt() != null) {
+            return analysisUpdate(stmt.updatestmt());
+        }
+        if (stmt.deletestmt() != null) {
+            return analysisDelete(stmt.deletestmt());
+        }
+        return null;
+    }
+
+    private BackupStatement analysisUpdate(PgSqlParser.UpdatestmtContext ctx) {
+        // CTE、多表 FROM 参照、RETURNING 均不是纯单表变更，跳过备份
+        if (ctx.with_clause_() != null || ctx.from_clause() != null || ctx.returning_clause() != null) {
+            return null;
+        }
+        return buildStatement(SplitQueryType.UPDATE, ctx.relation_expr_opt_alias(), ctx.where_or_current_clause());
+    }
+
+    private BackupStatement analysisDelete(PgSqlParser.DeletestmtContext ctx) {
+        // CTE、USING 多表、RETURNING 跳过备份
+        if (ctx.with_clause_() != null || ctx.using_clause() != null || ctx.returning_clause() != null) {
+            return null;
+        }
+        return buildStatement(SplitQueryType.DELETE, ctx.relation_expr_opt_alias(), ctx.where_or_current_clause());
+    }
+
+    private BackupStatement buildStatement(SplitQueryType type, PgSqlParser.Relation_expr_opt_aliasContext relationCtx,
+                                           PgSqlParser.Where_or_current_clauseContext whereCtx) {
+        // FROM 片段保留语句里的别名原文，保证 WHERE 中的别名引用在备份 SELECT 中依然成立
+        String fromText = originalText(relationCtx);
+        String sourceTable = originalText(relationCtx.relation_expr().qualified_name());
+
+        String whereText = null;
+        if (whereCtx != null) {
+            whereText = originalText(whereCtx);
+            if (WHERE_CURRENT_OF.matcher(whereText).find()) {
+                return null;
+            }
+        }
+
+        BackupStatement statement = new BackupStatement();
+        statement.setStatementType(type);
+        statement.setSourceTable(sourceTable);
+        statement.setHasWhere(whereText != null);
+        if (whereText != null) {
+            statement.setSelectSql("SELECT * FROM " + fromText + " " + whereText);
+        } else {
+            statement.setSelectSql("SELECT * FROM " + fromText);
+        }
+        return statement;
+    }
+
+    @Override
+    public String reverseDdl(String query) {
+        List<AstSplitScript> scripts;
+        try {
+            scripts = DslHelper.splitDsl(provider, new StringReader(query));
+        } catch (Exception e) {
+            return null;
+        }
+        if (scripts.size() != 1) {
+            return null;
+        }
+        ParseTree astTree = scripts.get(0).getAstTree();
+        if (!(astTree instanceof PgSqlParser.StmtContext)) {
+            return null;
+        }
+        PgSqlParser.StmtContext stmt = (PgSqlParser.StmtContext) astTree;
+        try {
+            if (stmt.createstmt() != null) {
+                return reverseCreateTable(stmt.createstmt());
+            }
+            if (stmt.indexstmt() != null) {
+                return reverseCreateIndex(stmt.indexstmt());
+            }
+            if (stmt.altertablestmt() != null) {
+                return reverseAlterTable(stmt.altertablestmt());
+            }
+        } catch (Exception e) {
+            return null;
+        }
+        return null;
+    }
+
+    private String reverseCreateTable(PgSqlParser.CreatestmtContext ctx) {
+        // IF NOT EXISTS 语义下表可能本来就存在，逆向 DROP 会误删旧表，跳过
+        if (ctx.if_not_exists_() != null) {
+            return null;
+        }
+        List<PgSqlParser.Qualified_nameContext> names = ctx.qualified_name();
+        if (names == null || names.isEmpty()) {
+            return null;
+        }
+        return "DROP TABLE " + originalText(names.get(0)) + ";";
+    }
+
+    private String reverseCreateIndex(PgSqlParser.IndexstmtContext ctx) {
+        // 匿名索引名字由数据库生成，无法静态推导；IF NOT EXISTS 同 CREATE TABLE 的顾虑，均跳过
+        if (ctx.index_name_() == null || ctx.IF_P() != null) {
+            return null;
+        }
+        String indexName = originalText(ctx.index_name_()).trim();
+        // 索引与表同 schema：表名带 schema 前缀时，DROP INDEX 也补同样前缀
+        String schemaPrefix = "";
+        if (ctx.relation_expr() != null) {
+            String table = originalText(ctx.relation_expr());
+            int dotIndex = table.lastIndexOf('.');
+            if (dotIndex > 0) {
+                schemaPrefix = table.substring(0, dotIndex + 1);
+            }
+        }
+        return "DROP INDEX " + schemaPrefix + indexName + ";";
+    }
+
+    private String reverseAlterTable(PgSqlParser.AltertablestmtContext ctx) {
+        // 只逆向"全部子命令都是 ADD COLUMN"的 ALTER：混入其他操作（DROP/ALTER TYPE/ADD CONSTRAINT）时整条放弃
+        if (ctx.relation_expr() == null || ctx.alter_table_cmds() == null) {
+            return null;
+        }
+        String table = originalText(ctx.relation_expr());
+        List<String> dropColumns = new ArrayList<>();
+        for (PgSqlParser.Alter_table_cmdContext cmd : ctx.alter_table_cmds().alter_table_cmd()) {
+            // 文法按 label 生成子类：只有 ADD [COLUMN]（AddColumnContext）可逆；
+            // IF NOT EXISTS 存在时列可能本来就有，逆向 DROP 会误删旧列，整条放弃
+            if (!(cmd instanceof PgSqlParser.AddColumnContext)) {
+                return null;
+            }
+            PgSqlParser.AddColumnContext addColumn = (PgSqlParser.AddColumnContext) cmd;
+            if (addColumn.IF_P() != null || addColumn.columnDef() == null) {
+                return null;
+            }
+            dropColumns.add("ALTER TABLE " + table + " DROP COLUMN " + originalText(addColumn.columnDef().colid()) + ";");
+        }
+        if (dropColumns.isEmpty()) {
+            return null;
+        }
+        Collections.reverse(dropColumns);
+        return String.join("\n", dropColumns);
+    }
+
+    /** 从原始输入流取 ctx 的原文，保留大小写、引号和内部空白 */
+    private String originalText(ParserRuleContext ctx) {
+        return ctx.start.getInputStream().getText(Interval.of(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+    }
+}


### PR DESCRIPTION
## Summary

Add an optional SQL-engine SPI that analyzes MySQL and PostgreSQL statements for prior row backup and safe DDL reversal.

The analyzer returns the target table and an affected-row `SELECT` for eligible single-table `UPDATE` / `DELETE` statements. It deliberately skips shapes whose affected rows cannot be reproduced safely, including CTEs, multi-table changes, `RETURNING`, cursor predicates, and MySQL `ORDER BY` / `LIMIT` changes.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Add `PriorBackupSpi` and `BackupStatement` to the SQL plugin SDK.
- Expose the optional capability from `SqlEngineSpi` without affecting engines that do not implement it.
- Implement affected-row analysis for plain MySQL and PostgreSQL `UPDATE` / `DELETE` statements.
- Generate reverse DDL only for safe additive operations such as create table/index and add column.
- Cache analyzers per parser configuration in the MySQL and PostgreSQL engines.
- Preserve the official PostgreSQL lineage disablement from #229.

## Test Plan

- [ ] Not tested (explain why below)
- [x] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [x] Backend build
- [ ] Manual verification

Details:

```text
:cgdm-plugin-sdk:compileJava :sql-mysql:compileJava :sql-postgres:compileJava --rerun-tasks
:sql-mysql:test :sql-postgres:test
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [ ] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
