### PR TITLE
fix(openapi): clean up failed sync queries and apply client timeouts

### DIFF
--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/config/ConsoleConfig.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/config/ConsoleConfig.java
@@ -69,6 +69,8 @@ public class ConsoleConfig {
     private boolean        autoUpdateInnerRules;
     @Value("${clougence.clouddm.console.openapi.timeout:120}")
     private Integer        openApiTimeout;
+    @Value("${clougence.clouddm.console.openapi.query-timeout:54}")
+    private Integer        openApiQueryTimeout;
     @Value("${clougence.rdp.console.csrf:false}")
     private Boolean        activeCsrfCheck;
     @Value("${clougence.rdp.login.retry.max-count:5}")

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/config/ConsoleConfig.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/component/config/ConsoleConfig.java
@@ -69,8 +69,6 @@ public class ConsoleConfig {
     private boolean        autoUpdateInnerRules;
     @Value("${clougence.clouddm.console.openapi.timeout:120}")
     private Integer        openApiTimeout;
-    @Value("${clougence.clouddm.console.openapi.query-timeout:54}")
-    private Integer        openApiQueryTimeout;
     @Value("${clougence.rdp.console.csrf:false}")
     private Boolean        activeCsrfCheck;
     @Value("${clougence.rdp.login.retry.max-count:5}")

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/controller/openapi/QueryApi.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/controller/openapi/QueryApi.java
@@ -17,9 +17,8 @@ package com.clougence.clouddm.console.web.controller.openapi;
 
 import static com.clougence.clouddm.sdk.security.auth.def.SecRoleAuthLabel.DM_QUERY_CONSOLE;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -31,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.clougence.clouddm.api.common.rpc.ResWebData;
 import com.clougence.clouddm.api.common.rpc.ResWebDataUtils;
+import com.clougence.clouddm.console.web.component.config.ConsoleConfig;
 import com.clougence.clouddm.console.web.constants.DmControllerUrlPrefix;
 import com.clougence.clouddm.console.web.constants.DmMcpI18nKey;
 import com.clougence.clouddm.console.web.global.jwtsession.RequestAuth;
@@ -65,13 +65,15 @@ public class QueryApi {
     private DsQueryEditorService queryEditorService;
     @Resource
     private ConsoleQueryApi      consoleQueryApi;
+    @Resource
+    private ConsoleConfig        consoleConfig;
 
     @McpTool(value = DmMcpI18nKey.M_EXECUTE_QUERY)
     @RequestAuth(DM_QUERY_CONSOLE)
     @RequestMapping(value = "/syncQuery", method = RequestMethod.POST)
     public ResWebData<DmApiQueryResultVO> syncQuery(@Valid @RequestBody DmApiDsQueryFO fo, HttpServletRequest request) {
         String requestId = (String) request.getAttribute(OpenApiSessionManager.OPEN_API_REQUEST_ID);
-        log.info("syncQuery for open api request id :" + requestId);
+        log.info("syncQuery for open api, requestId: {}", requestId);
 
         // prepare query
         String puid = (String) request.getAttribute(RdpUserService.PUID);
@@ -97,25 +99,30 @@ public class QueryApi {
         this.consoleQueryApi.offerQueryRequest(queryFO, msg -> applyMessageResult(queryFO, msg, resultData, future));
 
         // wait result
-        int DEFAULT_QUERY_TIMEOUT_SEC = 54;
+        int queryTimeout = this.consoleConfig.getOpenApiQueryTimeout();
         try {
-            DmApiQueryResultVO r = future.get(DEFAULT_QUERY_TIMEOUT_SEC, TimeUnit.SECONDS);
-            return ResWebDataUtils.buildSuccess(r);
+            DmApiQueryResultVO result = future.get(queryTimeout, TimeUnit.SECONDS);
+            return ResWebDataUtils.buildSuccess(requestId, result);
         } catch (TimeoutException e) {
-            return ResWebDataUtils.buildError("Query timeout(" + DEFAULT_QUERY_TIMEOUT_SEC + " sec) in CloudDM");
+            this.closeSession(puid, uid, sessionId, requestId);
+            return ResWebDataUtils.buildError("QUERY_TIMEOUT", "Query timeout(" + queryTimeout + " sec) in CloudDM", requestId);
         } catch (InterruptedException e) {
-            return ResWebDataUtils.buildError("Query interrupted in CloudDM");
+            this.closeSession(puid, uid, sessionId, requestId);
+            Thread.currentThread().interrupt();
+            return ResWebDataUtils.buildError("QUERY_INTERRUPTED", "Query interrupted in CloudDM", requestId);
         } catch (Exception e) {
-            Throwable root = e;
-            if (e instanceof ExecutionException) {
-                root = e.getCause();
-            }
-            String msg = "Error convert data.cause:" + ExceptionUtils.getRootCauseMessage(root);
-            log.error(msg, root);
+            this.closeSession(puid, uid, sessionId, requestId);
+            Throwable root = e instanceof ExecutionException && e.getCause() != null ? e.getCause() : e;
+            log.error("syncQuery failed, requestId: {}", requestId, root);
+            return ResWebDataUtils.buildError("QUERY_FAILED", "Query failed: " + ExceptionUtils.getRootCauseMessage(root), requestId);
+        }
+    }
 
-            StringWriter sw = new StringWriter();
-            root.printStackTrace(new PrintWriter(sw));
-            return ResWebDataUtils.buildError("Query Error in CloudDM, Message:" + sw);
+    private void closeSession(String puid, String uid, String sessionId, String requestId) {
+        try {
+            this.queryEditorService.closeSession(puid, uid, List.of(sessionId));
+        } catch (Exception e) {
+            log.warn("close timed out open api session failed, requestId: {}, sessionId: {}", requestId, sessionId, e);
         }
     }
 

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/controller/openapi/QueryApi.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/controller/openapi/QueryApi.java
@@ -30,7 +30,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.clougence.clouddm.api.common.rpc.ResWebData;
 import com.clougence.clouddm.api.common.rpc.ResWebDataUtils;
-import com.clougence.clouddm.console.web.component.config.ConsoleConfig;
 import com.clougence.clouddm.console.web.constants.DmControllerUrlPrefix;
 import com.clougence.clouddm.console.web.constants.DmMcpI18nKey;
 import com.clougence.clouddm.console.web.global.jwtsession.RequestAuth;
@@ -65,8 +64,6 @@ public class QueryApi {
     private DsQueryEditorService queryEditorService;
     @Resource
     private ConsoleQueryApi      consoleQueryApi;
-    @Resource
-    private ConsoleConfig        consoleConfig;
 
     @McpTool(value = DmMcpI18nKey.M_EXECUTE_QUERY)
     @RequestAuth(DM_QUERY_CONSOLE)
@@ -99,7 +96,7 @@ public class QueryApi {
         this.consoleQueryApi.offerQueryRequest(queryFO, msg -> applyMessageResult(queryFO, msg, resultData, future));
 
         // wait result
-        int queryTimeout = this.consoleConfig.getOpenApiQueryTimeout();
+        int queryTimeout = 54;
         try {
             DmApiQueryResultVO result = future.get(queryTimeout, TimeUnit.SECONDS);
             return ResWebDataUtils.buildSuccess(requestId, result);

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/controller/openapi/QueryApi.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/controller/openapi/QueryApi.java
@@ -93,11 +93,11 @@ public class QueryApi {
         // do query
         final CgFuture<DmApiQueryResultVO> future = new CgFutureObj<>();
         final DmApiQueryResultVO resultData = new DmApiQueryResultVO();
-        this.consoleQueryApi.offerQueryRequest(queryFO, msg -> applyMessageResult(queryFO, msg, resultData, future));
 
         // wait result
         int queryTimeout = 54;
         try {
+            this.consoleQueryApi.offerQueryRequest(queryFO, msg -> applyMessageResult(queryFO, msg, resultData, future));
             DmApiQueryResultVO result = future.get(queryTimeout, TimeUnit.SECONDS);
             return ResWebDataUtils.buildSuccess(requestId, result);
         } catch (TimeoutException e) {

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/rdp/component/openapi/OpenApiHttpClient.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/rdp/component/openapi/OpenApiHttpClient.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import com.clougence.rdp.component.openapi.exception.ClientException;
 import com.clougence.rdp.component.openapi.exception.ServerException;
@@ -61,7 +62,12 @@ public class OpenApiHttpClient {
             Map<String, String> commonParams = genCommonParams();
             String url = genFullUrl(uri, commonParams);
 
-            OkHttpClient client = new OkHttpClient();
+            OkHttpClient client = new OkHttpClient.Builder()//
+                .connectTimeout(openApiTimeout, TimeUnit.SECONDS)//
+                .readTimeout(openApiTimeout, TimeUnit.SECONDS)//
+                .writeTimeout(openApiTimeout, TimeUnit.SECONDS)//
+                .callTimeout(openApiTimeout, TimeUnit.SECONDS)//
+                .build();
             RequestBody body = RequestBody.create(JSON, content);
             Request request = new Request.Builder().url(url).post(body).build();
             response = client.newCall(request).execute();


### PR DESCRIPTION
## Summary

Clean up synchronous OpenAPI query sessions when waiting ends abnormally, and make the OpenAPI HTTP client honor its existing timeout argument.

Previously, `syncQuery` returned after a timeout, interruption, or unexpected failure without closing the query session. This could leave the query and its database resources active after the caller had already stopped waiting. The HTTP client also ignored its timeout constructor argument and used OkHttp defaults.

This PR keeps the existing local 54-second `syncQuery` wait and does not add any `ConsoleConfig` property.

## User-visible behavior

- Timed-out, interrupted, and failed synchronous queries close their query session.
- Interrupted requests restore the thread interrupt flag after cleanup.
- Success and error responses preserve the OpenAPI request ID.
- Unexpected failures are logged on the server without returning a Java stack trace to the caller.
- The OpenAPI HTTP client applies its existing timeout argument to connect, read, write, and total call timeouts.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Close query sessions after timeout, interruption, and exceptional completion.
- Restore the interrupt flag after interrupted waits.
- Preserve request IDs in success and error responses.
- Return the root error message instead of a server stack trace.
- Configure OkHttp from the timeout already supplied to `OpenApiHttpClient`.
- Keep the existing 54-second synchronous-query wait local to `QueryApi`.

## Test Plan

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [x] Backend build
- [ ] Manual verification

Details:

```text
:cgdm-console:compileJava --max-workers=8
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [ ] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
