### PR TITLE
fix(websocket): improve transport error handling

### DIFF
--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/global/ws/WsChannel.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/global/ws/WsChannel.java
@@ -135,8 +135,10 @@ public class WsChannel extends TextWebSocketHandler implements UnifiedPostConstr
     @Override
     public void handleTransportError(WebSocketSession wss, Throwable e) throws Exception {
         String message = ExceptionUtils.getRootCauseMessage(e);
-        log.error(e.getMessage(), message);
-        WsUtils.writeToSocket(wss, WsType.WS_RES_ERROR, message);
+        log.error("WS[" + WsUtils.getChannelKey(wss) + "]:TRANSPORT_ERROR " + message, e);
+        if (wss.isOpen()) {
+            WsUtils.writeToSocket(wss, WsType.WS_RES_ERROR, message);
+        }
         wss.close(CloseStatus.NORMAL);
     }
 


### PR DESCRIPTION
## Summary

Improve WebSocket transport-error logging and avoid writing an error frame after the session has already closed.

The previous logger call treated the exception message as a formatting pattern and passed the root-cause text as an unused argument, which could log `null` and omitted the exception stack. It also attempted to write an error response regardless of connection state.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- Log the channel key, root-cause message, and full exception.
- Send the WebSocket error frame only while the session remains open.
- Preserve the existing normal-close behavior.

## Test Plan

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [x] Backend build
- [ ] Manual verification

Details:

```text
:cgdm-console:compileJava --max-workers=8
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [ ] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
