### PR TITLE
chore(release): bump version to 4.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | Homepage | https://www.cdmgr.com/                          |
 | Documentation | https://www.cdmgr.com/docs/intro/product_intro  |
 | License | Apache License 2.0                              |
-| Current version | 4.1.0                                           |
+| Current version | 4.1.1                                           |
 | Main languages | Java, JavaScript / TypeScript                   |
 | Deployment modes | Standalone (Alone), Cluster (Console + Sidecar) |
 | Deployment targets | Install package, Docker, Kubernetes             |
@@ -93,7 +93,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.0
+  bladepipe/cgdm-alone:4.1.1
 
 # Faster image pulls in China
 docker run -d --name cgdm-alone \
@@ -102,7 +102,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.0
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
 ```
 
 Host directory mount example:
@@ -116,7 +116,7 @@ docker run -d --name cgdm-alone \
   -v /data/cgdm/logs:/root/cgdm/alone/logs \
   -v /data/cgdm/data:/root/cgdm/alone/data \
   -v /data/cgdm/mysql:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.0
+  bladepipe/cgdm-alone:4.1.1
 ```
 
 When `/data/cgdm/conf` is empty, CloudDM initializes it with the default configuration files on startup.
@@ -140,25 +140,25 @@ Before upgrading, back up Docker volumes or database data. To upgrade, remove th
 ```bash
 # Default image
 docker rm -f cgdm-alone
-docker pull bladepipe/cgdm-alone:4.1.0
+docker pull bladepipe/cgdm-alone:4.1.1
 docker run -d --name cgdm-alone \
   -p 8222:8222 \
   -v cgdm_alone_conf:/root/cgdm/alone/conf \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.0
+  bladepipe/cgdm-alone:4.1.1
 
 # China acceleration image
 docker rm -f cgdm-alone
-docker pull cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.0
+docker pull cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
 docker run -d --name cgdm-alone \
   -p 8222:8222 \
   -v cgdm_alone_conf:/root/cgdm/alone/conf \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.0
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
 ```
 
 ### Initialization

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,7 +1,7 @@
 #
 org.gradle.jvmargs=-Xmx8192m -Djava.net.preferIPv4Stack=true
 #
-cg.clouddm.main.version=4.1.0
+cg.clouddm.main.version=4.1.1
 #
 cg.lib.jackson.version=2.19.0
 cg.lib.slf4j.version=2.0.17

--- a/docs/README.cn.md
+++ b/docs/README.cn.md
@@ -32,7 +32,7 @@
 | 官网   | https://www.cdmgr.com/                         |
 | 文档   | https://www.cdmgr.com/docs/intro/product_intro |
 | 开源协议 | Apache License 2.0                             |
-| 当前版本 | 4.1.0                                          |
+| 当前版本 | 4.1.1                                          |
 | 主要语言 | Java、JavaScript / TypeScript                   |
 | 部署模式 | 单机模式（Alone）、集群模式（Console + Sidecar）            |
 | 部署方式 | 安装包、Docker、Kubernetes                          |
@@ -97,7 +97,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.0
+  bladepipe/cgdm-alone:4.1.1
 
 # 中国地区，使用加速镜像
 docker run -d --name cgdm-alone \
@@ -106,7 +106,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.0
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
 ```
 
 本地目录挂载示例：
@@ -120,7 +120,7 @@ docker run -d --name cgdm-alone \
   -v /data/cgdm/logs:/root/cgdm/alone/logs \
   -v /data/cgdm/data:/root/cgdm/alone/data \
   -v /data/cgdm/mysql:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.0
+  bladepipe/cgdm-alone:4.1.1
 ```
 
 当 `/data/cgdm/conf` 是空目录时，CloudDM 会在启动时自动写入默认配置文件。
@@ -145,25 +145,25 @@ gunzip -c cgdm-alone-image-<arch>.tar.gz | docker load
 ```bash
 # 默认镜像
 docker rm -f cgdm-alone
-docker pull bladepipe/cgdm-alone:4.1.0
+docker pull bladepipe/cgdm-alone:4.1.1
 docker run -d --name cgdm-alone \
   -p 8222:8222 \
   -v cgdm_alone_conf:/root/cgdm/alone/conf \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.0
+  bladepipe/cgdm-alone:4.1.1
 
 # 中国区加速镜像
 docker rm -f cgdm-alone
-docker pull cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.0
+docker pull cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
 docker run -d --name cgdm-alone \
   -p 8222:8222 \
   -v cgdm_alone_conf:/root/cgdm/alone/conf \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.0
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
 ```
 
 ### 初始化

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -31,7 +31,7 @@
 | Homepage           | https://www.cdmgr.com/                          |
 | Documentation      | https://www.cdmgr.com/docs/intro/product_intro  |
 | License            | Apache License 2.0                              |
-| Current version    | 4.1.0                                           |
+| Current version    | 4.1.1                                           |
 | Main languages     | Java, JavaScript / TypeScript                   |
 | Deployment modes   | Standalone (Alone), Cluster (Console + Sidecar) |
 | Deployment targets | Install package, Docker, Kubernetes             |
@@ -99,7 +99,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.0
+  bladepipe/cgdm-alone:4.1.1
 
 # Faster image pulls in China
 docker run -d --name cgdm-alone \
@@ -108,7 +108,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.0
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
 ```
 
 Host directory mount example:
@@ -122,7 +122,7 @@ docker run -d --name cgdm-alone \
   -v /data/cgdm/logs:/root/cgdm/alone/logs \
   -v /data/cgdm/data:/root/cgdm/alone/data \
   -v /data/cgdm/mysql:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.0
+  bladepipe/cgdm-alone:4.1.1
 ```
 
 When `/data/cgdm/conf` is empty, CloudDM initializes it with the default configuration files on startup.
@@ -150,25 +150,25 @@ with the same volumes.
 ```bash
 # Default image
 docker rm -f cgdm-alone
-docker pull bladepipe/cgdm-alone:4.1.0
+docker pull bladepipe/cgdm-alone:4.1.1
 docker run -d --name cgdm-alone \
   -p 8222:8222 \
   -v cgdm_alone_conf:/root/cgdm/alone/conf \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.0
+  bladepipe/cgdm-alone:4.1.1
 
 # China acceleration image
 docker rm -f cgdm-alone
-docker pull cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.0
+docker pull cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
 docker run -d --name cgdm-alone \
   -p 8222:8222 \
   -v cgdm_alone_conf:/root/cgdm/alone/conf \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.0
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
 ```
 
 ### Initialization

--- a/docs/guides/deployment.cn.md
+++ b/docs/guides/deployment.cn.md
@@ -97,11 +97,11 @@ http://localhost:8222
 
 ```bash
 # 一键启动
-docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.0
+docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.1
 
 # 中国镜像加速
 docker run -d --name cgdm-alone -p 8222:8222 \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.0
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
 ```
 
 持久化数据卷：
@@ -114,7 +114,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.0
+  bladepipe/cgdm-alone:4.1.1
 
 # 挂载到宿主机目录
 mkdir -p /data/cgdm/{conf,logs,data,mysql}
@@ -125,7 +125,7 @@ docker run -d --name cgdm-alone \
   -v /data/cgdm/logs:/root/cgdm/alone/logs \
   -v /data/cgdm/data:/root/cgdm/alone/data \
   -v /data/cgdm/mysql:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.0
+  bladepipe/cgdm-alone:4.1.1
 ```
 
 当 `/data/cgdm/conf` 是空目录时，容器启动时会自动写入默认配置文件。
@@ -137,7 +137,7 @@ docker run -d --name cgdm-alone \
 ```yml
 services:
   dm_alone:
-    image: clougence/cgdm-alone:4.1.0
+    image: clougence/cgdm-alone:4.1.1
     container_name: cgdm-alone
     restart: always
     ports:
@@ -277,7 +277,7 @@ docker run -d --name dm_console \
   -e DB_DATABASE=cdmgr \
   -e DB_USERNAME=root \
   -e DB_PASSWORD=123456 \
-  bladepipe/cgdm-console:4.1.0
+  bladepipe/cgdm-console:4.1.1
 
 # 启动 Sidecar
 docker run -d --name dm_sidecar \
@@ -288,13 +288,13 @@ docker run -d --name dm_sidecar \
   -e DM_CLIENT_WSN=<请替换为实际值> \
   -e APP_SERVE_NAME=dm_console \
   -e APP_SERVE_PORT=8008 \
-  bladepipe/cgdm-sidecar:4.1.0
+  bladepipe/cgdm-sidecar:4.1.1
 ```
 
 中国区部署时，只需将镜像替换为：
 
-- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-console:4.1.0`
-- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-sidecar:4.1.0`
+- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-console:4.1.1`
+- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-sidecar:4.1.1`
 
 ### 4.3 使用 Docker Compose
 
@@ -316,7 +316,7 @@ services:
     command: [ "mysqld", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]
 
   dm_console:
-    image: clougence/cgdm-console:x86_64-4.1.0
+    image: clougence/cgdm-console:x86_64-4.1.1
     container_name: cgdm-console
     restart: always
     ports:
@@ -341,7 +341,7 @@ services:
       DB_PASSWORD: 123456
 
   dm_sidecar:
-    image: clougence/cgdm-sidecar:x86_64-4.1.0
+    image: clougence/cgdm-sidecar:x86_64-4.1.1
     container_name: cgdm-sidecar
     restart: always
     depends_on:

--- a/docs/guides/deployment.en.md
+++ b/docs/guides/deployment.en.md
@@ -97,11 +97,11 @@ The system automatically enters the initialization wizard. After completing data
 
 ```bash
 # One-click startup
-docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.0
+docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.1
 
 # China registry acceleration
 docker run -d --name cgdm-alone -p 8222:8222 \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.0
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
 ```
 
 Persistent data volumes:
@@ -114,7 +114,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.0
+  bladepipe/cgdm-alone:4.1.1
 
 # Mount to host directories
 mkdir -p /data/cgdm/{conf,logs,data,mysql}
@@ -125,7 +125,7 @@ docker run -d --name cgdm-alone \
   -v /data/cgdm/logs:/root/cgdm/alone/logs \
   -v /data/cgdm/data:/root/cgdm/alone/data \
   -v /data/cgdm/mysql:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.0
+  bladepipe/cgdm-alone:4.1.1
 ```
 
 When `/data/cgdm/conf` is empty, the container initializes it with the default configuration files on startup.
@@ -137,7 +137,7 @@ After the build is complete, deployment files named `docker-alone-xxx.yml` will 
 ```yml
 services:
   dm_alone:
-    image: clougence/cgdm-alone:4.1.0
+    image: clougence/cgdm-alone:4.1.1
     container_name: cgdm-alone
     restart: always
     ports:
@@ -277,7 +277,7 @@ docker run -d --name dm_console \
   -e DB_DATABASE=cdmgr \
   -e DB_USERNAME=root \
   -e DB_PASSWORD=123456 \
-  bladepipe/cgdm-console:4.1.0
+  bladepipe/cgdm-console:4.1.1
 
 # Start Sidecar
 docker run -d --name dm_sidecar \
@@ -288,13 +288,13 @@ docker run -d --name dm_sidecar \
   -e DM_CLIENT_WSN=<replace_with_actual_value> \
   -e APP_SERVE_NAME=dm_console \
   -e APP_SERVE_PORT=8008 \
-  bladepipe/cgdm-sidecar:4.1.0
+  bladepipe/cgdm-sidecar:4.1.1
 ```
 
 For China deployment, simply replace the images with:
 
-- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-console:4.1.0`
-- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-sidecar:4.1.0`
+- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-console:4.1.1`
+- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-sidecar:4.1.1`
 
 ### 4.3 Use Docker Compose
 
@@ -316,7 +316,7 @@ services:
     command: [ "mysqld", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]
 
   dm_console:
-    image: clougence/cgdm-console:x86_64-4.1.0
+    image: clougence/cgdm-console:x86_64-4.1.1
     container_name: cgdm-console
     restart: always
     ports:
@@ -341,7 +341,7 @@ services:
       DB_PASSWORD: 123456
 
   dm_sidecar:
-    image: clougence/cgdm-sidecar:x86_64-4.1.0
+    image: clougence/cgdm-sidecar:x86_64-4.1.1
     container_name: cgdm-sidecar
     restart: always
     depends_on:

--- a/docs/reference/faq.cn.md
+++ b/docs/reference/faq.cn.md
@@ -15,7 +15,7 @@ CloudDM 是一款免费且开源的团队化数据库管理平台，提供数据
 使用单机模式 Docker 镜像，并访问 `http://localhost:8222`：
 
 ```bash
-docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.0
+docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.1
 ```
 
 ### 评估或试用时应该选择哪种部署模式？

--- a/docs/reference/faq.en.md
+++ b/docs/reference/faq.en.md
@@ -15,7 +15,7 @@ Yes. CloudDM is released under the Apache License 2.0. See [LICENSE.txt](../../L
 Use the standalone Docker image and open `http://localhost:8222`:
 
 ```bash
-docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.0
+docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.1
 ```
 
 ### Which deployment mode should I use for evaluation?

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -4,6 +4,7 @@ Release notes are grouped by version. Each version directory contains one file p
 
 | Version | Chinese | English |
 |---------|---------|---------|
+| v4.1.1 | [中文](v4.1.1/index.cn.md) | [English](v4.1.1/index.en.md) |
 | v4.1.0 | [中文](v4.1.0/index.cn.md) | [English](v4.1.0/index.en.md) |
 | v4.0.1 | [中文](v4.0.1/index.cn.md) | [English](v4.0.1/index.en.md) |
 | v4.0.0 | [中文](v4.0.1/index.cn.md) | [English](v4.0.1/index.en.md) |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14,7 +14,7 @@ CloudDM is a free and open-source database management platform for teams, provid
 | Homepage | https://www.cdmgr.com/ |
 | Documentation | https://www.cdmgr.com/docs/intro/product_intro |
 | License | Apache License 2.0 |
-| Current version | 4.1.0 |
+| Current version | 4.1.1 |
 | Main languages | Java, JavaScript / TypeScript |
 | Deployment modes | Standalone (Alone), Cluster (Console + Sidecar) |
 | Deployment targets | Install package, Docker, Kubernetes |
@@ -67,14 +67,14 @@ CloudDM can be deployed with install packages, Docker, Docker Compose, or Kubern
 Run CloudDM in standalone mode with Docker:
 
 ```bash
-docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.0
+docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.1
 ```
 
 For faster image pulls in China:
 
 ```bash
 docker run -d --name cgdm-alone -p 8222:8222 \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.0
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
 ```
 
 After startup, open:


### PR DESCRIPTION
## Summary

Prepare Open CDM 4.1.1 by aligning the Gradle main version and public version references, including Docker image examples, deployment guides, FAQs, and the release-note index.

> Note: the new release-note index entry points to `docs/release-notes/v4.1.1/`, but the bilingual release-note files are not part of this version-only change and should be added before merge if the links must resolve in this PR.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Test
- [x] Build / tooling
- [ ] Other

## Changes

- Update `cg.clouddm.main.version` from `4.1.0` to `4.1.1`.
- Update current-version tables and Docker image tags across the root README, bilingual documentation, deployment guides, FAQs, and `llms-full.txt`.
- Add the `v4.1.1` entry to the release-note index.

## Test Plan

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [ ] Backend build
- [x] Manual verification

Details:

```text
PASS: change_open_cdm_version.py --version 4.1.1 --dry-run -> changes=0 after applying
PASS: cd backend && ./gradlew -q properties -> cg.clouddm.main.version: 4.1.1
PASS: git diff --check
PASS: stale 4.1.0 scan across non-historical public-version files -> no matches
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [x] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes. (N/A: version metadata and documentation only)
- [x] I checked that generated files, dependency directories, logs, and local artifacts are not included.
