### PR TITLE
fix(docker): reconcile embedded MySQL account from persisted config

### DIFF
--- a/package/docker/shared/alone/init.sh
+++ b/package/docker/shared/alone/init.sh
@@ -20,7 +20,11 @@ WAIT_DB_TIMEOUT_SECONDS=${WAIT_DB_TIMEOUT_SECONDS:-120}
 WAIT_MYSQL_STOP_SECONDS=${WAIT_MYSQL_STOP_SECONDS:-30}
 
 sql_escape() {
-  printf '%s' "$1" | sed "s/'/''/g"
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e "s/'/''/g"
+}
+
+sql_identifier_escape() {
+  printf '%s' "$1" | sed 's/`/``/g'
 }
 
 sed_replacement_escape() {
@@ -120,14 +124,14 @@ configure_embedded_mysql() {
   local escaped_db_password
 
   escaped_root_password=$(sql_escape "$MYSQL_ROOT_PASSWORD")
-  escaped_db_name=$(sql_escape "$DB_DATABASE")
+  escaped_db_name=$(sql_identifier_escape "$DB_DATABASE")
 
   mysql_sql <<SQL
 ALTER USER 'root'@'localhost' IDENTIFIED BY '${escaped_root_password}';
 CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED BY '${escaped_root_password}';
 ALTER USER 'root'@'127.0.0.1' IDENTIFIED BY '${escaped_root_password}';
 GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;
-CREATE DATABASE IF NOT EXISTS ${escaped_db_name};
+CREATE DATABASE IF NOT EXISTS \`${escaped_db_name}\`;
 FLUSH PRIVILEGES;
 SQL
 
@@ -137,7 +141,7 @@ SQL
     mysql_sql <<SQL
 CREATE USER IF NOT EXISTS '${escaped_db_user}'@'%' IDENTIFIED BY '${escaped_db_password}';
 ALTER USER '${escaped_db_user}'@'%' IDENTIFIED BY '${escaped_db_password}';
-GRANT ALL PRIVILEGES ON ${escaped_db_name}.* TO '${escaped_db_user}'@'%';
+GRANT ALL PRIVILEGES ON \`${escaped_db_name}\`.* TO '${escaped_db_user}'@'%';
 FLUSH PRIVILEGES;
 SQL
   fi
@@ -225,6 +229,57 @@ wait_for_embedded_mysql() {
   echo "embedded mysql is ready."
 }
 
+persisted_conf_value() {
+  awk -v key="$1" 'index($0, key "=") == 1 { print substr($0, length(key) + 2) }' "$DST_CONF_FILE" | tail -n 1 | tr -d '\r'
+}
+
+# The persisted alone.properties is the source of truth for the embedded mysql
+# application account: env vars are not replayed on container recreate, so a
+# restart must recover the account (or its password) from the persisted config.
+load_persisted_datasource_conf() {
+  local jdbc_url jdbc_target jdbc_host db_name db_user db_password
+
+  if [ ! -f "$DST_CONF_FILE" ]; then
+    return
+  fi
+
+  jdbc_url=$(persisted_conf_value spring.datasource.jdbcurl)
+  jdbc_target="${jdbc_url#jdbc:mysql://}"
+  if [ -z "$jdbc_target" ] || [ "$jdbc_target" = "$jdbc_url" ]; then
+    echo "persisted alone.properties has no mysql jdbc url, keep env datasource settings."
+    return
+  fi
+  jdbc_host="${jdbc_target%%/*}"
+  jdbc_host="${jdbc_host%%:*}"
+  if [ "$jdbc_host" != "127.0.0.1" ] && [ "$jdbc_host" != "localhost" ]; then
+    echo "persisted jdbc url does not target the embedded mysql, keep env datasource settings."
+    return
+  fi
+
+  db_user=$(persisted_conf_value spring.datasource.username)
+  if [ -z "$db_user" ]; then
+    echo "persisted alone.properties has no datasource username, keep env datasource settings."
+    return
+  fi
+  db_password=$(persisted_conf_value spring.datasource.password)
+
+  db_name=""
+  case "$jdbc_target" in
+    */*)
+      db_name="${jdbc_target#*/}"
+      db_name="${db_name%%\?*}"
+      db_name="${db_name%%;*}"
+      ;;
+  esac
+
+  echo "reconciling embedded mysql application account from persisted alone.properties."
+  if [ -n "$db_name" ]; then
+    DB_DATABASE="$db_name"
+  fi
+  DB_USERNAME="$db_user"
+  DB_PASSWORD="$db_password"
+}
+
 bootstrap_embedded_mysql() {
   setup_mysql_directories
   if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
@@ -295,6 +350,7 @@ fi
 
 if [ "$MYSQL_EMBEDDED" = "true" ]; then
   DB_HOST=127.0.0.1
+  load_persisted_datasource_conf
   bootstrap_embedded_mysql
 elif [ -n "$DB_HOST" ]; then
   wait_for_db "$DB_HOST" "$DB_PORT"


### PR DESCRIPTION
## Problem

When `MYSQL_EMBEDDED=true`, `package/docker/shared/alone/init.sh` maintains the embedded MySQL application account only from environment variables (`DB_USERNAME` defaults to `root`); the persisted `alone.properties` is never consulted. If the container is later recreated by a deployment that does not re-pass the datasource env vars (a common Compose setup), and the account in `mysql.user` is missing or its password has drifted, startup never restores it. The application then cannot connect to its own embedded database and boots into the initialization app instead of the console: REST APIs return `No static resource`, the UI redirects to `#/initialization` and shows `Access denied` — even though all business data in the persisted volume is intact.

We hit exactly this on a production 4.1.0 rollout: the persisted config referenced a dedicated account that no longer existed in `mysql.user`, and every container recreate landed on the initialization screen. Note that `/healthcheck` still returns HTTP 200 in this state, so shallow probes do not catch it.

## Fix

- Treat the persisted `alone.properties` as the source of truth for the embedded datasource account: when `MYSQL_EMBEDDED=true` and the JDBC URL targets the local embedded instance (`127.0.0.1`/`localhost`), read database/username/password from it, create the account if missing and re-sync the password if drifted (`CREATE USER IF NOT EXISTS` + `ALTER USER`).
- Keep the application account scoped to the target database only — no global privileges, no `GRANT OPTION`.
- Harden SQL escaping: escape backslashes in string literals in addition to single quotes, and quote the database name as a backtick identifier (it was previously interpolated with string-literal escaping).
- External database mode (`MYSQL_EMBEDDED=false`) is untouched: no accounts are created or modified.
- Credentials never appear in startup output.

## Testing

Scenario harness on a throwaway `mysql:8.0` container driving this `init.sh` directly (app start stubbed), all passing:

1. fresh install with a dedicated account → account created, grant scoped to the target database only
2. restart without `DB_*` env vars → account reconciled from the persisted config, login OK
3. account dropped, restart without env vars → recreated automatically (the previous script leaves the instance broken — this reproduces the production incident)
4. password drifted, restart → restored to the persisted password
5. password containing `'`, `\`, `` ` `` → created and connects, no credential in output
6. persisted JDBC URL pointing at an external host → env behavior kept, nothing reconciled
7. `MYSQL_EMBEDDED=false` with unreachable DB → fails fast, no embedded mysqld, no account statements

Also validated end-to-end on a real alone image: with the account deleted and no env vars passed, the old script reproduces the initialization-screen failure, while the patched script self-heals and the application reaches `systemStatus=Ready`.