### PR TITLE
fix(autoexec): open ticket session against the target catalog

### DIFF
--- a/backend/clouddm-platform/cgdm-api/src/main/java/com/clougence/clouddm/api/console/configs/ConfigRService.java
+++ b/backend/clouddm-platform/cgdm-api/src/main/java/com/clougence/clouddm/api/console/configs/ConfigRService.java
@@ -16,6 +16,7 @@
 package com.clougence.clouddm.api.console.configs;
 
 import java.util.List;
+import java.util.Map;
 
 import com.clougence.clouddm.base.metadata.ds.DataSourceConfig;
 import com.clougence.clouddm.base.metadata.ds.SshConfig;
@@ -33,6 +34,12 @@ public interface ConfigRService {
     List<ConfigData> fetchSettings(List<String> names);
 
     DataSourceConfig fetchDsConfig(long dsId);
+
+    /**
+     * Same as {@link #fetchDsConfig(long)} but applies datasource config overrides, so a worker can open the
+     * session against a database other than the datasource default.
+     */
+    DataSourceConfig fetchDsConfigWithOverrides(long dsId, Map<String, String> configOverrides);
 
     List<ConfigData> fetchDsConfig(String instanceId, List<String> names);
 

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/provider/ConfigRServiceProvider.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/provider/ConfigRServiceProvider.java
@@ -79,6 +79,11 @@ public class ConfigRServiceProvider extends AbstractBasicProvider implements Con
     }
 
     @Override
+    public DataSourceConfig fetchDsConfigWithOverrides(long dsId, Map<String, String> configOverrides) {
+        return this.dsConfigService.fetchDsConfigFromExists(dsId, configOverrides);
+    }
+
+    @Override
     public List<ConfigData> fetchDsConfig(String instanceId, List<String> names) {
         if (StringUtils.isBlank(instanceId) || CollectionUtils.isEmpty(names)) {
             return Collections.emptyList();

--- a/backend/clouddm-platform/cgdm-sidecar/src/main/java/com/clougence/clouddm/worker/component/autoexec/AutoExecJob.java
+++ b/backend/clouddm-platform/cgdm-sidecar/src/main/java/com/clougence/clouddm/worker/component/autoexec/AutoExecJob.java
@@ -22,9 +22,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.security.MessageDigest;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HexFormat;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -47,13 +49,16 @@ import com.clougence.clouddm.comm.model.auth.WorkerIdentity;
 import com.clougence.clouddm.sdk.execute.resultset.echo.Result;
 import com.clougence.clouddm.sdk.execute.resultset.echo.ResultCount;
 import com.clougence.clouddm.sdk.execute.resultset.echo.ResultMessage;
+import com.clougence.clouddm.sdk.execute.dsconf.DsConfigField;
 import com.clougence.clouddm.sdk.execute.session.MessageLevel;
 import com.clougence.clouddm.sdk.execute.session.QueryRequest;
+import com.clougence.clouddm.sdk.execute.session.SessionContextDTO;
 import com.clougence.clouddm.worker.component.report.ReportUtils;
 import com.clougence.clouddm.worker.component.resource.TaskDsResourceManager;
 import com.clougence.clouddm.worker.component.session.SessionAgent;
 import com.clougence.clouddm.worker.component.session.SessionManager;
 import com.clougence.utils.JsonUtils;
+import com.clougence.utils.StringUtils;
 import com.clougence.utils.ThreadUtils;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.MappingIterator;
@@ -126,7 +131,12 @@ public class AutoExecJob implements Runnable {
 
             // create session
             try {
-                DataSourceConfig dsConfig = this.configRService.fetchDsConfig(this.job.getDsId());
+                // The catalog/schema chosen for the ticket only lives in SessionContextDTO. Databases such as
+                // PostgreSQL cannot switch database on an open connection, so the connection has to be opened
+                // against the target database. Mirrors sessionConfigOverrides on the console side.
+                Map<String, String> configOverrides = sessionConfigOverrides(this.job.getContextDTO());
+                DataSourceConfig dsConfig = configOverrides.isEmpty() ? this.configRService.fetchDsConfig(this.job.getDsId())
+                    : this.configRService.fetchDsConfigWithOverrides(this.job.getDsId(), configOverrides);
                 this.sessionAgent = this.sessionManager.createSession(backgroundRM, dsConfig, this.job.getContextDTO());
                 String currentQueryId = this.sessionAgent.getCurrentQueryId();
                 sendMessage(AutoExecMessageDTO.createQueryIdMessage(this.job.getJobId(), currentQueryId), true);
@@ -421,6 +431,26 @@ public class AutoExecJob implements Runnable {
             this.workerIdentity = ReportUtils.getIdentity();
         }
         return this.workerIdentity;
+    }
+
+    /**
+     * Turns the ticket's target catalog/schema into datasource config overrides so the session is opened
+     * against the database the ticket actually selected. Returns an empty map when no context is available,
+     * in which case the caller keeps the datasource defaults.
+     */
+    private Map<String, String> sessionConfigOverrides(SessionContextDTO context) {
+        Map<String, String> configOverrides = new HashMap<>();
+        if (context == null) {
+            return configOverrides;
+        }
+
+        if (StringUtils.isNotBlank(context.getRdbCatalog())) {
+            configOverrides.put(DsConfigField.DEFAULT_DATABASE.getConfigName(), context.getRdbCatalog());
+        }
+        if (StringUtils.isNotBlank(context.getRdbSchema())) {
+            configOverrides.put(DsConfigField.DEFAULT_SCHEMA.getConfigName(), context.getRdbSchema());
+        }
+        return configOverrides;
     }
 
     private void sendMessage(AutoExecMessageDTO message, boolean immediately) {


### PR DESCRIPTION
## Summary

An auto-exec job opens its session against the datasource default database instead of the catalog selected for the ticket, so on PostgreSQL every DML ticket fails with `relation "<schema>.<table>" does not exist`.

The catalog and schema picked for a ticket only live in `SessionContextDTO`. `AutoExecJob` rebuilt the session from the raw datasource config, so those values never reached the connection. PostgreSQL cannot switch database on an open connection, and when `defaultCatalog` is empty `PostgresqlDsFactory` falls back to the `postgres` database — the ticket then executes against a database where the target schema does not exist.

The console side already handles this: it converts the session context into datasource config overrides before opening a session. That is why running the same SQL in the query editor succeeds while the ticket fails. `ConfigRService` only exposed `fetchDsConfig(dsId)`, so a worker had no way to apply overrides.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- `ConfigRService`: add `fetchDsConfigWithOverrides(long dsId, Map<String, String> configOverrides)`.
- `ConfigRServiceProvider`: implement it by delegating to the existing `DmDsConfigService.fetchDsConfigFromExists(dsId, configOverrides)` — no new resolution logic.
- `AutoExecJob`: build overrides from `SessionContextDTO` (`rdbCatalog` → `DsConfigField.DEFAULT_DATABASE`, `rdbSchema` → `DsConfigField.DEFAULT_SCHEMA`) and open the session with them, mirroring the console behaviour.
- Jobs whose context carries no catalog or schema produce an empty override map and keep the previous code path, so existing setups are unaffected.

## Test Plan

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [x] Backend build
- [x] Manual verification

Reproduction, on a PostgreSQL datasource whose `defaultCatalog` is left empty:

1. Register the datasource, pick a database and schema other than `postgres`, and submit a change ticket containing an `INSERT` that uses a schema-qualified table name.
2. Before the fix the task fails with `relation "<schema>.<table>" does not exist` at the position of the table name, while the same statement runs fine in the query editor against the same datasource.
3. After the fix the ticket executes against the selected database and succeeds.

Verified on a 4.1.0 deployment that hit this in production: ticket execution failed while the query editor reported `current_database()` as the intended database. After applying this change the same ticket completed and the rows landed in the correct database.

`./gradlew :cgdm-sidecar:compileJava :cgdm-console:compileJava` passes.
