### PR TITLE
fix(postgres): resolve schema-qualified pgvector column types

### DIFF
--- a/backend/clouddm-utils/cg-schema/src/main/java/com/clougence/adapter/postgre/PostgresTypes.java
+++ b/backend/clouddm-utils/cg-schema/src/main/java/com/clougence/adapter/postgre/PostgresTypes.java
@@ -114,8 +114,8 @@ public enum PostgresTypes implements FieldType {
     // vector
     INT2VECTOR("int2vector", JDBCType.OTHER, null, false, false),
     OIDVECTOR("oidvector", JDBCType.OTHER, null, false, false),
-    VECTOR("vector", JDBCType.OTHER, null, false, false),
-    HALFVEC("halfvec", JDBCType.OTHER, null, false, false),
+    VECTOR("vector", JDBCType.OTHER, null, false, true),
+    HALFVEC("halfvec", JDBCType.OTHER, null, false, true),
 
     // --------------------------------------------------------------------------------------------------------------------------
     SMALLINT_ARRAY("smallint[]", JDBCType.ARRAY, Oid.INT2_ARRAY, true, false), // smallint、int2


### PR DESCRIPTION
## Summary

A `vector` or `halfvec` column whose type is reported schema-qualified (for example `public.vector` or `extensions.vector`) fails to resolve with `UnsupportedOperationException: Unsupported postgres columnType`.

`PostgresTypes.valueOfCode` first tries an exact match on the type name and then, only when the type is declared with `needFullName`, accepts a qualified name by suffix match. `VECTOR` and `HALFVEC` are declared with `needFullName = false`, so the qualified form never matches and resolution throws.

pgvector is an extension type, and PostgreSQL reports it schema-qualified whenever the schema that owns the extension is not on the current `search_path` — a common setup when extensions are installed into a dedicated schema.

Every other extension type in this enum already sets the flag:

```java
GEOMETRY("geometry",  JDBCType.OTHER, null, false, true),
GEOGRAPHY("geography", JDBCType.OTHER, null, false, true),
HSTORE("hstore",     JDBCType.OTHER, null, false, true),
CITEXT("citext",     JDBCType.OTHER, null, false, true),
```

so this looks like an oversight for the two pgvector entries rather than an intentional difference.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- `PostgresTypes`: set `needFullName` for `VECTOR` and `HALFVEC`, matching the other extension types in the enum.

## Test Plan

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [x] Backend build
- [x] Manual verification

Reproduction on PostgreSQL with pgvector installed into a schema outside `search_path`:

1. `CREATE EXTENSION vector SCHEMA extensions;`
2. Create a table with a `extensions.vector` column and browse it in the console.
3. Before the change the column type fails to resolve with `Unsupported postgres columnType extensions.vector`; after the change it resolves to `VECTOR`, matching how `geometry` and `hstore` already behave.

`./gradlew :cg-schema:compileJava` passes.
