### PR TITLE
fix(openapi): report execution errors and warnings to API callers

### DIFF
--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/controller/openapi/QueryApi.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/controller/openapi/QueryApi.java
@@ -180,10 +180,13 @@ public class QueryApi {
                 if (vo.getMsgList() == null) {
                     vo.setMsgList(new ArrayList<>());
                 }
-                for (WsInfoEntity entity : m.getEntities()) {
-                    if (entity.getMode() == MessageMode.Console) {
-                        vo.getMsgList().add(m);
-                    }
+                // Errors and warnings are relevant to an API caller regardless of the display mode they were
+                // produced for. Decide once per message so a message carrying several matching entities is
+                // reported a single time.
+                if (m.getEntities().stream().anyMatch(entity -> entity.getMode() == MessageMode.Console
+                        || entity.getLevel() == MessageLevel.Error
+                        || entity.getLevel() == MessageLevel.Warn)) {
+                    vo.getMsgList().add(m);
                 }
                 break;
             }


### PR DESCRIPTION
## Summary

A synchronous OpenAPI query drops execution errors and warnings, so a caller can receive a response with no indication that something went wrong.

`QueryApi` only collects messages whose mode is `MessageMode.Console`. An entity carrying `MessageLevel.Error` or `MessageLevel.Warn` for any other display mode is discarded, and `msgList` comes back without it.

While fixing that, the same block appends the message once per matching entity:

```java
for (WsInfoEntity entity : m.getEntities()) {
    if (entity.getMode() == MessageMode.Console) {
        vo.getMsgList().add(m);   // same m added again for each matching entity
    }
}
```

A message carrying several `Console` entities is therefore duplicated in `msgList` today, and widening the condition alone would have made that more likely. The check now runs once per message instead.

## Related Issues

None.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build / tooling
- [ ] Other

## Changes

- `QueryApi`: include messages carrying `MessageLevel.Error` or `MessageLevel.Warn` in addition to `MessageMode.Console`.
- Evaluate the condition once per message via `anyMatch` instead of per entity, so a message with several matching entities is reported a single time.

## Test Plan

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [x] Backend build
- [x] Manual verification

Manual check through the synchronous OpenAPI query endpoint:

1. Run a statement that produces a non-Console warning or error (for example a statement rejected by a security rule). Before the change `msgList` is empty; after the change it carries the error entry.
2. Run a statement producing several `Console` entities in one message. Before the change the message appears in `msgList` once per entity; after the change it appears once.

`./gradlew :cgdm-console:compileJava` passes.
