### PR TITLE
chore(github): simplify contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,73 +1,24 @@
-name: Issue report
-description: Report a bug, suggest a feature, or propose a documentation improvement.
+name: Issue 反馈
+description: 报告缺陷、提出功能建议或文档改进意见。
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for helping improve CloudDM.
+        感谢你帮助改进 CloudDM。
 
-        Use a clear title prefixed with `[Bug]`, `[Feature]`, or `[Docs]`. For security vulnerabilities, do not include secrets or other sensitive information in a public issue.
+        请简单描述遇到的问题或你的建议，不要包含密码、令牌等敏感信息。
 
-  - type: dropdown
-    id: issue-type
+  - type: textarea
+    id: description
     attributes:
-      label: Issue type
-      description: Select the category that best describes this issue.
-      options:
-        - Bug report
-        - Feature request
-        - Documentation
-        - Other
+      label: 问题或建议
+      description: 请告诉我们发生了什么，或者你希望 CloudDM 支持什么。
+      placeholder: 在这里填写内容。
     validations:
       required: true
-
-  - type: textarea
-    id: summary
-    attributes:
-      label: Summary
-      description: Briefly describe the issue or request.
-      placeholder: What happened, or what would you like CloudDM to support?
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual-behavior
-    attributes:
-      label: Actual behavior
-      description: For bugs, describe what happened instead, including any visible error messages.
-      placeholder: What did CloudDM do?
-
-  - type: textarea
-    id: environment
-    attributes:
-      label: Environment
-      description: For bugs, include every relevant version and deployment detail.
-      value: |
-        - CloudDM version:
-        - Deployment mode: Alone / Console + Sidecar
-        - Operating system:
-        - Browser and version:
-        - Database type and version:
-
-  - type: textarea
-    id: logs
-    attributes:
-      label: Logs or screenshots
-      description: Paste relevant logs or attach screenshots. Remove passwords, tokens, connection strings, and other sensitive data.
-      placeholder: Add logs, screenshots, or a minimal reproduction here.
 
   - type: textarea
     id: additional-context
     attributes:
-      label: Additional context
-      description: Add related issues, possible solutions, or comparable implementations.
-
-  - type: checkboxes
-    id: checklist
-    attributes:
-      label: Checklist
-      options:
-        - label: I searched existing issues and did not find a duplicate.
-          required: true
-        - label: I removed passwords, tokens, connection strings, and other sensitive data.
-          required: true
+      label: 补充信息（可选）
+      description: 可以添加截图、日志、环境信息或关联 issue。

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,48 +1,32 @@
-## Summary
+## 变更摘要
 
-<!-- Briefly describe what changed and why. -->
+<!-- 简要说明本次改动的内容和原因。 -->
 
-## Related Issues
+## 关联 Issue
 
-<!-- Link related issues or write "None". Example: Closes #123 -->
+<!-- 填写关联 issue，或写“无”。例如：Closes #123 -->
 
-## Type of Change
+## 测试计划（必填）
 
-- [ ] Bug fix
-- [ ] Feature
-- [ ] Refactor
-- [ ] Documentation
-- [ ] Test
-- [ ] Build / tooling
-- [ ] Other
+<!-- 请勿删除或留空。至少勾选一项，并在“详细说明”中写明测试范围、步骤和结果；如未测试，请说明原因。 -->
 
-## Changes
+- [ ] 未测试（请在下方说明原因）
+- [ ] 单元测试
+- [ ] 集成测试
+- [ ] 前端 lint / 构建
+- [ ] 后端构建
+- [ ] 人工验证
 
-<!-- List the main implementation changes. -->
-
-- 
-
-## Test Plan
-
-<!-- Describe the commands or manual checks you ran. -->
-
-- [ ] Not tested (explain why below)
-- [ ] Unit tests
-- [ ] Integration tests
-- [ ] Frontend lint / build
-- [ ] Backend build
-- [ ] Manual verification
-
-Details:
+详细说明：
 
 ```text
 
 ```
 
-## Checklist
+## 检查清单
 
-- [ ] The PR title clearly describes the change.
-- [ ] The change follows the repository coding standards.
-- [ ] Documentation was updated when behavior or usage changed.
-- [ ] Tests were added or updated for behavior changes.
-- [ ] I checked that generated files, dependency directories, logs, and local artifacts are not included.
+- [ ] PR 标题清楚描述了改动内容。
+- [ ] 改动符合仓库编码规范。
+- [ ] 当行为或用法发生变化时，已更新文档。
+- [ ] 已为行为变更补充或更新测试。
+- [ ] 已确认不包含生成文件、依赖目录、日志和本地构建产物。


### PR DESCRIPTION
## Change Summary

- Change the PR template to Chinese and explicitly make the test plan mandatory.
- Simplify the Issue template so that it retains only the problem or suggestion description and optional additional information.
- Reduce the effort required for users to submit Issues while ensuring that PRs include clear verification details.

## Related Issues

None

## Test Plan (Required)

- [x] Manual verification

Details:

```text
- Used a Ruby YAML parser to verify that issue.yml has valid syntax and confirmed that it contains only one required input.
- Ran git diff --check; it passed.
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [x] Documentation was updated when behavior or usage changed.
- [x] I checked that generated files, dependency directories, logs, and local build artifacts are not included.