### PR TITLE
fix(openapi): apply data source permission checks to management APIs

### DIFF
--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/controller/openapi/DataSourceApi.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/controller/openapi/DataSourceApi.java
@@ -15,6 +15,9 @@
  */
 package com.clougence.clouddm.console.web.controller.openapi;
 
+import static com.clougence.clouddm.sdk.security.auth.def.SecRoleAuthLabel.RDP_DS_MANAGE;
+import static com.clougence.clouddm.sdk.security.auth.def.SecRoleAuthLabel.RDP_DS_READ;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -38,6 +41,7 @@ import com.clougence.clouddm.console.web.constants.DmMcpI18nKey;
 import com.clougence.clouddm.console.web.global.i18n.DmI18nUtils;
 import com.clougence.clouddm.console.web.global.i18n.I18nDmMsgKeys;
 import com.clougence.clouddm.console.web.global.jwtsession.RequestAuth;
+import com.clougence.clouddm.platform.dal.model.monitor.SecurityLevel;
 import com.clougence.clouddm.console.web.global.mcp.McpApiProvider;
 import com.clougence.clouddm.console.web.global.mcp.model.McpTool;
 import com.clougence.clouddm.console.web.model.fo.openapi.DmApiDsDetailFO;
@@ -288,7 +292,7 @@ public class DataSourceApi extends BasicApi {
         return ResWebDataUtils.buildSuccess(vos);
     }
 
-    @RequestAuth(strategy = RequestAuth.AuthStrategy.Ignore)
+    @RequestAuth(level = SecurityLevel.HIGH, value = RDP_DS_MANAGE)
     @RequestMapping(value = "/deleteds", method = RequestMethod.POST)
     public ResApiData<?> deleteDs(@RequestBody @Valid ApiDeleteDsFO data, HttpServletRequest request) {
         String requestId = (String) request.getAttribute(OpenApiSessionManager.OPEN_API_REQUEST_ID);
@@ -300,7 +304,7 @@ public class DataSourceApi extends BasicApi {
         return ResApiDataUtils.buildSuccess(requestId, null);
     }
 
-    @RequestAuth(strategy = RequestAuth.AuthStrategy.Ignore)
+    @RequestAuth(RDP_DS_MANAGE)
     @RequestMapping(value = "/updatedatasourcedesc", method = RequestMethod.POST)
     public ResApiData<?> updateDataSourceDesc(@RequestBody @Valid ApiUpdateDsDescFO updateFO, HttpServletRequest request) {
         String requestId = (String) request.getAttribute(OpenApiSessionManager.OPEN_API_REQUEST_ID);
@@ -312,7 +316,7 @@ public class DataSourceApi extends BasicApi {
         return ResApiDataUtils.buildSuccess(requestId);
     }
 
-    @RequestAuth(strategy = RequestAuth.AuthStrategy.Ignore)
+    @RequestAuth(level = SecurityLevel.HIGH, value = RDP_DS_MANAGE)
     @RequestMapping(value = "/updateaccountandpassword", method = RequestMethod.POST)
     public ResApiData<?> updateAccountAndPassword(@RequestParam("DataSourceUpdateData") String data,
                                                   @RequestParam(value = "securityFile", required = false) MultipartFile securityFile,
@@ -325,7 +329,7 @@ public class DataSourceApi extends BasicApi {
         return ResApiDataUtils.buildSuccess(requestId);
     }
 
-    @RequestAuth(strategy = RequestAuth.AuthStrategy.Ignore)
+    @RequestAuth(RDP_DS_READ)
     @RequestMapping(value = "/querydsconfig", method = RequestMethod.POST)
     public ResApiData<?> queryDsCOnfig(@RequestBody @Valid ApiListDsKvConfigsByDsIdFO fo, HttpServletRequest request) {
         String requestId = (String) request.getAttribute(OpenApiSessionManager.OPEN_API_REQUEST_ID);
@@ -337,7 +341,7 @@ public class DataSourceApi extends BasicApi {
         return ResApiDataUtils.buildSuccess(requestId, apiConfVos);
     }
 
-    @RequestAuth(strategy = RequestAuth.AuthStrategy.Ignore)
+    @RequestAuth(level = SecurityLevel.HIGH, value = RDP_DS_MANAGE)
     @RequestMapping(value = "/upsertdsconfig", method = RequestMethod.POST)
     public ResApiData<?> upsertDsConfig(@RequestBody @Valid ApiUpsertDsKvConfigFO configFO, HttpServletRequest request) {
         String requestId = (String) request.getAttribute(OpenApiSessionManager.OPEN_API_REQUEST_ID);


### PR DESCRIPTION
## Change type

bugfix (permission check)

## Problem

The data source management endpoints in `DataSourceApi` are annotated with `@RequestAuth(strategy = RequestAuth.AuthStrategy.Ignore)`, so they perform **no permission check at all** — any valid AccessKey can call them:

| Endpoint | Impact |
|---|---|
| `/api/open/datasource/deleteds` | delete a data source |
| `/api/open/datasource/updateaccountandpassword` | change data source credentials |
| `/api/open/datasource/upsertdsconfig` | modify data source configuration |
| `/api/open/datasource/updatedatasourcedesc` | modify data source description |
| `/api/open/datasource/querydsconfig` | read data source configuration |

The equivalent Web endpoints in `DmDsController` are guarded:

```java
@RequestAuth(level = SecurityLevel.HIGH, value = RDP_DS_MANAGE)
@RequestMapping(value = "/addDs", method = RequestMethod.POST)
```

So the same operation is permission-checked in the console but unchecked over OpenAPI. A user whose role does not include data source management can still perform it by using their AccessKey.

## Reproduce

1. Create a user whose role has no `RDP_DS_MANAGE` (e.g. a query-only role).
2. Obtain that user's AccessKey/SecretKey.
3. Call `POST /api/open/datasource/deleteds` signed with it.

Observed: the request passes authorization and reaches the service layer — with a non-existent id it returns `DataSource (x) not exist` rather than a permission error, showing no permission gate was applied.

Expected: rejected for insufficient permissions, as the console does.

## Fix

Replace `AuthStrategy.Ignore` with the same role permissions the console uses:

- `deleteds` / `updateaccountandpassword` / `upsertdsconfig` → `HIGH` + `RDP_DS_MANAGE`
- `updatedatasourcedesc` → `RDP_DS_MANAGE`
- `querydsconfig` (read-only) → `RDP_DS_READ`

Any user whose role grants these permissions can still perform the operations, matching console behaviour; roles without them are now rejected.

## Note on the previous revision

The first revision of this PR restricted these endpoints to the primary account by comparing `UID` with `PUID`. As @zycgit pointed out, the primary account is a fixed constant and multi-tenancy is not a design goal, so that was the wrong axis — the operation should be available to any user holding the permission. Reworked accordingly; the change is now limited to the `@RequestAuth` annotations and needs no new i18n message.

## Verification

`./gradlew :cgdm-console:compileJava` passes on `dev`.