### PR TITLE
feat(mongodb): accept toArray() on find cursors

### DIFF
--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/antlr/MongoLexer.g4
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/antlr/MongoLexer.g4
@@ -74,6 +74,7 @@ FIND: 'find';
 S_SKIP: 'skip';
 LIMIT:  'limit';
 SORT:   'sort';
+TO_ARRAY: 'toArray';
 S_COMMENT: 'comment';
 BATCH_SIZE: 'batchSize';
 MAX_TIME_MS: 'maxTimeMS';

--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/antlr/MongoParser.g4
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/antlr/MongoParser.g4
@@ -203,6 +203,9 @@ findConstarint:
     | SHOW_RECORD_ID LS_BRACKET bool=(TRUE|FALSE) RS_BRACKET #findShowRecordIdConstraint
     | LET LS_BRACKET jsonString RS_BRACKET #findLetConstraint
     | EXPLAIN LS_BRACKET verbosity=STRING? RS_BRACKET #explainConstraint
+    // mongosh uses toArray() to materialize the cursor; the result set is already
+    // materialized here, so it is accepted syntactically without changing semantics
+    | TO_ARRAY LS_BRACKET RS_BRACKET #findToArrayConstraint
     ;
 
 findOne:
@@ -302,6 +305,7 @@ keyWordId:
     | S_SKIP
     | LIMIT
     | SORT
+    | TO_ARRAY
     | MAX
     | MIN
     | ALLOW_DISK_USE

--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/DefaultMongoParserVisitor.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/DefaultMongoParserVisitor.java
@@ -693,6 +693,12 @@ public class DefaultMongoParserVisitor extends AbstractLocationParseTreeVisitor<
         return null;
     }
 
+    /** toArray() only materializes the cursor in mongosh; the result set is already materialized here */
+    @Override
+    public Object visitFindToArrayConstraint(MongoParser.FindToArrayConstraintContext ctx) {
+        return null;
+    }
+
     @Override
     public Object visitFindCollationConstraint(MongoParser.FindCollationConstraintContext ctx) {
         FindFunc func = (FindFunc) this.instStack.peek();


### PR DESCRIPTION
## Change type

bugfix / small feature (MongoDB syntax compatibility)

## Problem

`toArray()` is the idiomatic way to materialize a cursor in mongosh:

```js
db.coll.find({}).limit(5).toArray()
```

`findConstarint` in `MongoParser.g4` enumerates the supported chained methods (`skip`, `limit`, `sort`, `comment`, `maxTimeMS`, `collation`, `allowDiskUse`, `max`, `min`, `returnKey`, `showRecordId`, `let`, `explain`) but does not include `toArray`. The statement therefore fails to parse, and the only feedback is the generic message from `CONSOLE_QUERY_SYNTAX_ANALYSIS_ERROR`:

```
At 1 row 40 column, the statement could not be parsed.
```

which gives no hint about which part is unsupported.

This affects **both** entry points, since the Web SQL console (via `WsChannelStore`) and the OpenAPI `execute` endpoint (via `QueryApi`) both go through `ConsoleQueryApi.offerQueryRequest` and share the same parser.

Statements without `toArray` — `find().limit()`, `findOne()`, `countDocuments()`, `getCollectionNames()` — all work, so the gap is specific to this one cursor method.

## Fix

Add a `TO_ARRAY` token and a `findToArrayConstraint` alternative. The result set returned here is already materialized, so `toArray` carries no extra semantics — it is accepted syntactically and the visitor is a no-op.

## Compatibility note

`toArray` becomes a keyword, so a collection literally named `toArray` can no longer be addressed as `db.toArray.xxx`. This matches the existing behaviour of keywords such as `limit`, `sort` and `find` (`db.limit.find({})` does not parse today either), and both escape forms keep working:

- `db.getCollection("toArray").find({}).limit(1)` — OK
- `db['toArray'].find({}).limit(1)` — OK

## Verification

Driving the generated parser directly on `dev` with the patch applied:

| statement | before | after |
|---|---|---|
| `db.c.find({}).limit(5).toArray()` | PARSE-FAIL | OK |
| `db.c.find({}).sort({a:1}).limit(5).toArray()` | PARSE-FAIL | OK |
| `db.c.find({}).skip(2).limit(3).toArray()` | PARSE-FAIL | OK |
| `db.c.find({}).limit(5)` | OK | OK |
| `db.c.findOne()` / `countDocuments()` / `getCollectionNames()` | OK | OK |

`./gradlew :sql-mongodb:compileJava` passes; `ds-mongodb` and `cgdm-console` also compile against the regenerated parser.