### PR TITLE
fix(mysql): correct data type display and result handling

### DIFF
--- a/backend/clouddm-platform/cgdm-components/cg-com-results-file/src/main/java/com/clougence/clouddm/component/resultfile/ResultFileReader.java
+++ b/backend/clouddm-platform/cgdm-components/cg-com-results-file/src/main/java/com/clougence/clouddm/component/resultfile/ResultFileReader.java
@@ -179,7 +179,8 @@ public class ResultFileReader implements ResultReader {
 
     public ResultSetValue readAsString(ColMetaData meta, QueryResultConf conf) throws IOException {
         DataHeader header = this.resultInput.nextDataHeader();
-        return readAsString(meta, conf, 0, header.getLength());
+        long displayLength = header.getType() == EntityType.Bytes ? hexadecimalDisplaySize(header.getLength()) : header.getLength();
+        return readAsString(meta, conf, 0, displayLength);
     }
 
     @Override
@@ -283,11 +284,23 @@ public class ResultFileReader implements ResultReader {
             case EntityType.Bytes: {
                 try {
                     this.resultInput.readStream(header);
+                    totalSize = hexadecimalDisplaySize(header.getLength());
+                    long safeOffset = Math.max(0, Math.min(offset, totalSize));
+                    long safeLength = Math.max(0, length);
+                    long remainingCharacters = totalSize - safeOffset;
+                    long requestedCharacters = Math.min(safeLength, remainingCharacters);
+                    long byteOffset = safeOffset / 2;
+                    int leadingNibble = (int) (safeOffset % 2);
+                    long byteLength = (leadingNibble + requestedCharacters + 1) / 2;
+
                     ByteArrayOutputStream tmp = new ByteArrayOutputStream();
-                    IOUtils.copyLarge(this.resultInput, tmp, offset, length);
+                    IOUtils.copyLarge(this.resultInput, tmp, byteOffset, byteLength);
                     byte[] tmpBytes = tmp.toByteArray();
-                    value = HexadecimalUtils.bytes2hex(tmpBytes);
-                    moreSize = this.resultInput.available();
+                    String hexadecimal = HexadecimalUtils.bytes2hex(tmpBytes);
+                    int valueStart = Math.min(leadingNibble, hexadecimal.length());
+                    int valueEnd = (int) Math.min(hexadecimal.length(), valueStart + requestedCharacters);
+                    value = hexadecimal.substring(valueStart, valueEnd);
+                    moreSize = Math.max(0, totalSize - safeOffset - value.length());
                 } finally {
                     this.resultInput.finishReadData();
                 }
@@ -346,5 +359,9 @@ public class ResultFileReader implements ResultReader {
         } else {
             return ResultSetValue.of(complete, mask, value, moreSize, totalSize);
         }
+    }
+
+    private static long hexadecimalDisplaySize(long byteSize) {
+        return byteSize > Long.MAX_VALUE / 2 ? Long.MAX_VALUE : byteSize * 2;
     }
 }

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/service/editor/DsDataEditorServiceImpl.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/service/editor/DsDataEditorServiceImpl.java
@@ -72,6 +72,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 public class DsDataEditorServiceImpl implements DsDataEditorService {
 
+    @Resource
     private DmDsConfigService   dmDsConfigService;
     @Resource
     private DsSchemaService     dsSchemaService;
@@ -288,25 +289,7 @@ public class DsDataEditorServiceImpl implements DsDataEditorService {
         // execute sql
         try {
             ResultList result = this.queryService.syncExecuteQuery(uid, sessionId, request);
-            for (Result r : result.getResultList()) {
-                if (r.getResultType() == ResultType.ResultSet) {
-                    return EditorConvertUtils.convertToEditorResultSet((ResultSet) r);
-                }
-                if (r.getResultType() == ResultType.Message) {
-                    ResultMessage resultMessage = (ResultMessage) r;
-                    if (resultMessage.getLevel() == MessageLevel.Error) {
-                        EditorResultSet resultDTO = new EditorResultSet();
-                        resultDTO.setSuccess(false);
-                        resultDTO.setMessage(resultMessage.getMessage());
-                        return resultDTO;
-                    }
-                }
-            }
-
-            EditorResultSet resultDTO = new EditorResultSet();
-            resultDTO.setSuccess(false);
-            resultDTO.setMessage(DmI18nUtils.getMessage(I18nDmMsgKeys.CONSOLE_DATA_EDITOR_QUERY_MISSING_RESULT_ERROR.name()));
-            return resultDTO;
+            return convertQueryResult(result);
         } catch (Exception e) {
             EditorResultSet resultDTO = new EditorResultSet();
             resultDTO.setSuccess(false);
@@ -331,31 +314,42 @@ public class DsDataEditorServiceImpl implements DsDataEditorService {
         // execute sql
         try {
             ResultList result = this.queryService.syncExecuteQuery(uid, sessionId, request);
-            for (Result r : result.getResultList()) {
-                if (r.getResultType() == ResultType.ResultSet) {
-                    return EditorConvertUtils.convertToEditorResultSet((ResultSet) r);
-                }
-                if (r.getResultType() == ResultType.Message) {
-                    ResultMessage resultMessage = (ResultMessage) r;
-                    if (resultMessage.getLevel() == MessageLevel.Error) {
-                        EditorResultSet resultDTO = new EditorResultSet();
-                        resultDTO.setSuccess(false);
-                        resultDTO.setMessage(resultMessage.getMessage());
-                        return resultDTO;
-                    }
-                }
-            }
-
-            EditorResultSet resultDTO = new EditorResultSet();
-            resultDTO.setSuccess(false);
-            resultDTO.setMessage(DmI18nUtils.getMessage(I18nDmMsgKeys.CONSOLE_DATA_EDITOR_QUERY_MISSING_RESULT_ERROR.name()));
-            return resultDTO;
+            return convertQueryResult(result);
         } catch (Exception e) {
             EditorResultSet resultDTO = new EditorResultSet();
             resultDTO.setSuccess(false);
             resultDTO.setMessage(e.getMessage());
             return resultDTO;
         }
+    }
+
+    private EditorResultSet convertQueryResult(ResultList result) {
+        ResultSetMeta meta = null;
+        ResultSet rows = null;
+        for (Result r : result.getResultList()) {
+            if (r.getResultType() == ResultType.ResultSetMeta) {
+                meta = (ResultSetMeta) r;
+            } else if (r.getResultType() == ResultType.ResultSet) {
+                rows = (ResultSet) r;
+            } else if (r.getResultType() == ResultType.Message) {
+                ResultMessage resultMessage = (ResultMessage) r;
+                if (resultMessage.getLevel() == MessageLevel.Error) {
+                    EditorResultSet resultDTO = new EditorResultSet();
+                    resultDTO.setSuccess(false);
+                    resultDTO.setMessage(resultMessage.getMessage());
+                    return resultDTO;
+                }
+            }
+        }
+
+        if (meta != null && rows != null) {
+            return EditorConvertUtils.convertToEditorResultSet(meta, rows);
+        }
+
+        EditorResultSet resultDTO = new EditorResultSet();
+        resultDTO.setSuccess(false);
+        resultDTO.setMessage(DmI18nUtils.getMessage(I18nDmMsgKeys.CONSOLE_DATA_EDITOR_QUERY_MISSING_RESULT_ERROR.name()));
+        return resultDTO;
     }
 
     private Reload doExecuteDml(String puid, String uid, String clientIp, String sessionId, DsLevels levels,//

--- a/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/service/editor/EditorConvertUtils.java
+++ b/backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/service/editor/EditorConvertUtils.java
@@ -67,27 +67,25 @@ public class EditorConvertUtils {
         return dto;
     }
 
-    public static EditorResultSet convertToEditorResultSet(ResultSet r) {
+    public static EditorResultSet convertToEditorResultSet(ResultSetMeta meta, ResultSet rows) {
         EditorResultSet dto = new EditorResultSet();
 
-        dto.setFetchTimeMs(r.getCostTimeMs());
-        dto.setResultId(r.getResultId());
-        dto.setFetchCount(r.getFetchCount());
+        dto.setFetchTimeMs(rows.getCostTimeMs());
+        dto.setResultId(rows.getResultId());
+        dto.setFetchCount(rows.getFetchCount());
 
-        dto.setSuccess(r.isSuccess());
-        dto.setMessage(r.getMessage());
+        dto.setSuccess(meta.isSuccess() && rows.isSuccess());
+        dto.setMessage(StringUtils.isNotBlank(rows.getMessage()) ? rows.getMessage() : meta.getMessage());
 
         dto.setUpdateCountResult(false);
         dto.setUpdateCount(0);
-        //dto.setGeneratedKeys(r.getGeneratedKeys());
 
-        dto.setSql(r.getQuerySql());
-        //dto.setColumnList(r.getColumnList());
-        //dto.setColumnType(r.getColumnType());
-        //dto.setRowSet(r.getRowSet());
-        //dto.setCacheFile(r.getCacheFileUri());
-        throw new UnsupportedOperationException("convertToEditorResultSet not support ResultSetRows temporarily");
-        //return dto;
+        dto.setSql(rows.getQuerySql());
+        dto.setColumnList(meta.getColumnList());
+        dto.setColumnType(meta.getColumnType());
+        dto.setRowSet(rows.getRowSet());
+        dto.setCacheFile(meta.getCacheFileUri());
+        return dto;
     }
 
     public static DataEditorResultDTO convertToDataEditorResultDTO(EditorResultSet result) {

--- a/backend/clouddm-platform/cgdm-sidecar/src/main/java/com/clougence/clouddm/worker/component/session/storage/RowStorage.java
+++ b/backend/clouddm-platform/cgdm-sidecar/src/main/java/com/clougence/clouddm/worker/component/session/storage/RowStorage.java
@@ -388,8 +388,9 @@ public class RowStorage implements Closeable {
                 try {
                     byte[] sample = ctx.sampleData(this.displayChars);
                     String displayed = HexadecimalUtils.bytes2hex(sample);
-                    long moreSize = fullSize - sample.length;
-                    return ResultSetValue.of(complete, mask, displayed, moreSize, fullSize);
+                    long displaySize = hexadecimalDisplaySize(fullSize);
+                    long moreSize = displaySize - displayed.length();
+                    return ResultSetValue.of(complete, mask, displayed, moreSize, displaySize);
                 } catch (IOException e) {
                     return ResultSetValue.ofError(complete, mask, e.getMessage());
                 }
@@ -402,8 +403,9 @@ public class RowStorage implements Closeable {
 
                 long fullSize = v.length;
                 String displayed = HexadecimalUtils.bytes2hex(sample);
-                long moreSize = fullSize - sample.length;
-                return ResultSetValue.of(complete, mask, displayed, moreSize, fullSize);
+                long displaySize = hexadecimalDisplaySize(fullSize);
+                long moreSize = displaySize - displayed.length();
+                return ResultSetValue.of(complete, mask, displayed, moreSize, displaySize);
             }
         }
     }
@@ -431,8 +433,9 @@ public class RowStorage implements Closeable {
             try {
                 byte[] sample = ctx.sampleData(this.displayChars);
                 String displayed = HexadecimalUtils.bytes2hex(sample);
-                long moreSize = fullSize - sample.length;
-                return ResultSetValue.of(complete, mask, displayed, moreSize, fullSize);
+                long displaySize = hexadecimalDisplaySize(fullSize);
+                long moreSize = displaySize - displayed.length();
+                return ResultSetValue.of(complete, mask, displayed, moreSize, displaySize);
             } catch (IOException e) {
                 return ResultSetValue.ofError(complete, mask, e.getMessage());
             }
@@ -625,5 +628,9 @@ public class RowStorage implements Closeable {
         boolean mask = tag == (tag | ResultDataTag.DATA_MASK_TAG);
         String columnType = ctx.getColumnType();
         return ResultSetValue.ofError(complete, mask, RowDataHelper.displayUnsupported(this.displayChars, columnType));
+    }
+
+    private static long hexadecimalDisplaySize(long byteSize) {
+        return byteSize > Long.MAX_VALUE / 2 ? Long.MAX_VALUE : byteSize * 2;
     }
 }

--- a/backend/clouddm-plugins/clouddm-ds/dsc-common-mysql/src/main/java/com/clougence/clouddm/dsfamily/mysql/execute/MyColReader.java
+++ b/backend/clouddm-plugins/clouddm-ds/dsc-common-mysql/src/main/java/com/clougence/clouddm/dsfamily/mysql/execute/MyColReader.java
@@ -19,6 +19,8 @@ import com.clougence.clouddm.base.metadata.ds.ColMetaData;
 import com.clougence.clouddm.dsfamily.execute.AbstractColReader;
 import com.clougence.clouddm.dsfamily.mysql.execute.fetcher.BitValueFetcher;
 import com.clougence.clouddm.dsfamily.mysql.execute.fetcher.MyGeometryValueFetcher;
+import com.clougence.clouddm.dsfamily.mysql.execute.fetcher.TimeStringValueFetcher;
+import com.clougence.clouddm.dsfamily.mysql.execute.fetcher.VectorValueFetcher;
 import com.clougence.clouddm.sdk.execute.session.result.fetcher.ValueFetcher;
 import com.clougence.utils.StringUtils;
 
@@ -30,8 +32,10 @@ import com.clougence.utils.StringUtils;
  **/
 public class MyColReader extends AbstractColReader {
 
-    public static final ValueFetcher BIT_VALUE_FETCHER   = new BitValueFetcher();
-    public static final ValueFetcher MY_GEOMETRY_FETCHER = new MyGeometryValueFetcher();
+    public static final ValueFetcher BIT_VALUE_FETCHER    = new BitValueFetcher();
+    public static final ValueFetcher MY_GEOMETRY_FETCHER  = new MyGeometryValueFetcher();
+    private static final ValueFetcher TIME_STRING_FETCHER  = new TimeStringValueFetcher();
+    private static final ValueFetcher VECTOR_VALUE_FETCHER = new VectorValueFetcher();
 
     @Override
     public ValueFetcher readColumn(String col, ColMetaData colMetaData) {
@@ -88,14 +92,17 @@ public class MyColReader extends AbstractColReader {
             case "longtext":
             case "json":
                 return STRING_AS_CLOB_FETCHER;
+            case "vector":
+                return VECTOR_VALUE_FETCHER;
             case "mediumblob":
             case "longblob":
                 return BYTES_AS_STREAM_FETCHER;
             case "date":     // '0000-00-00'
-            case "time":     // '-838:59:59'/'838:59:59'
             case "datetime": // '0000-00-00 00:00:00'
             case "timestamp":// '0000-00-00 00:00:00'
                 return STRING_VALUE_FETCHER;
+            case "time":     // '-838:59:59'/'838:59:59'
+                return TIME_STRING_FETCHER;
             case "year":
                 return SHORT_VALUE_FETCHER;
             case "geometry":

--- a/backend/clouddm-plugins/clouddm-ds/dsc-common-mysql/src/main/java/com/clougence/clouddm/dsfamily/mysql/execute/MyHooks.java
+++ b/backend/clouddm-plugins/clouddm-ds/dsc-common-mysql/src/main/java/com/clougence/clouddm/dsfamily/mysql/execute/MyHooks.java
@@ -18,6 +18,7 @@ package com.clougence.clouddm.dsfamily.mysql.execute;
 import java.sql.*;
 
 import com.clougence.clouddm.base.metadata.ds.ColMetaData;
+import com.clougence.clouddm.dsfamily.mysql.execute.fetcher.MyGeometryValueFetcher;
 import com.clougence.clouddm.dsfamily.mysql.dialect.MySqlDialect;
 import com.clougence.clouddm.sdk.execute.meta.DsMetaService;
 import com.clougence.clouddm.sdk.execute.session.QueryRequest;
@@ -29,6 +30,7 @@ import com.clougence.clouddm.sdk.execute.session.result.ColReader;
 import com.clougence.utils.StringUtils;
 import com.clougence.utils.jdbc.mapper.SingleRowMapper;
 import com.clougence.utils.jdbc.mapper.SingleValueRowMapper;
+import com.mysql.cj.jdbc.ConnectionImpl;
 
 /**
  * only for integration test
@@ -189,15 +191,31 @@ public class MyHooks implements SessionHook {
 
     @Override
     public PreparedStatement executeStatement(Connection conn, QueryRequest query) throws SQLException {
+        MyGeometryValueFetcher.prepareSpatialReferenceAxes(conn);
         PreparedStatement stmt;
         if (query.getResultConf().isReturnAutoIncrKey()) {
             stmt = conn.prepareStatement(query.getQueryBody(), Statement.RETURN_GENERATED_KEYS);
         } else {
-            stmt = conn.prepareStatement(query.getQueryBody(), ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+            stmt = this.prepareStatement(conn, query.getQueryBody(), ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
         }
 
         this.setFetchSize(stmt);
         return stmt;
+    }
+
+    private PreparedStatement prepareStatement(Connection conn, String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        if (this.requiresClientPreparedStatement(conn)) {
+            return conn.unwrap(ConnectionImpl.class).clientPrepareStatement(sql, resultSetType, resultSetConcurrency);
+        }
+        return conn.prepareStatement(sql, resultSetType, resultSetConcurrency);
+    }
+
+    private boolean requiresClientPreparedStatement(Connection conn) throws SQLException {
+        DatabaseMetaData metaData = conn.getMetaData();
+        // Connector/J 8.4 cannot decode MySQL 9 VECTOR (protocol type 242) in a
+        // binary server-prepared result set. Its text protocol exposes the same
+        // value as bytes, which lets VectorValueFetcher handle it normally.
+        return metaData.getDatabaseMajorVersion() >= 9 && metaData.getDriverMajorVersion() <= 8 && conn.isWrapperFor(ConnectionImpl.class);
     }
 
     protected void setFetchSize(PreparedStatement stmt) throws SQLException {

--- a/backend/clouddm-plugins/clouddm-ds/dsc-common-mysql/src/main/java/com/clougence/clouddm/dsfamily/mysql/execute/fetcher/MyGeometryValueFetcher.java
+++ b/backend/clouddm-plugins/clouddm-ds/dsc-common-mysql/src/main/java/com/clougence/clouddm/dsfamily/mysql/execute/fetcher/MyGeometryValueFetcher.java
@@ -16,10 +16,24 @@
 package com.clougence.clouddm.dsfamily.mysql.execute.fetcher;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequenceFilter;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.io.WKBReader;
@@ -27,9 +41,59 @@ import org.locationtech.jts.io.WKBReader;
 import com.clougence.clouddm.dsfamily.execute.fetcher.StringAsClobFetcher;
 import com.clougence.clouddm.sdk.execute.session.result.fetcher.ValueFetcherContext;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class MyGeometryValueFetcher extends StringAsClobFetcher {
 
-    private static final GeometryFactory factory = new GeometryFactory();
+    private static final GeometryFactory           factory                   = new GeometryFactory();
+    private static final Pattern                   AXIS_DIRECTION            = Pattern.compile("AXIS\\s*\\[\\s*\"[^\"]*\"\\s*,\\s*(NORTH|SOUTH|EAST|WEST)", Pattern.CASE_INSENSITIVE);
+    private static final Map<Connection, String>   CONNECTION_KEYS           = Collections.synchronizedMap(new WeakHashMap<>());
+    private static final Map<String, Set<Integer>> LATITUDE_FIRST_SRS_CACHE = new ConcurrentHashMap<>();
+    private static final CoordinateSequenceFilter  SWAP_XY_FILTER           = new CoordinateSequenceFilter() {
+
+        @Override
+        public void filter(CoordinateSequence sequence, int index) {
+            double x = sequence.getX(index);
+            sequence.setOrdinate(index, 0, sequence.getY(index));
+            sequence.setOrdinate(index, 1, x);
+        }
+
+        @Override
+        public boolean isDone() {
+            return false;
+        }
+
+        @Override
+        public boolean isGeometryChanged() {
+            return true;
+        }
+    };
+
+    public static void prepareSpatialReferenceAxes(Connection connection) {
+        String connectionKey = connectionKey(connection);
+        if (connectionKey == null) {
+            return;
+        }
+        CONNECTION_KEYS.put(connection, connectionKey);
+        if (LATITUDE_FIRST_SRS_CACHE.containsKey(connectionKey)) {
+            return;
+        }
+
+        Set<Integer> latitudeFirstSrids = new HashSet<>();
+        try (Statement statement = connection.createStatement(); ResultSet resultSet = statement.executeQuery(//
+                "SELECT SRS_ID, DEFINITION FROM information_schema.ST_SPATIAL_REFERENCE_SYSTEMS WHERE DEFINITION LIKE 'GEOGCS%'")) {
+            while (resultSet.next()) {
+                int srid = resultSet.getInt(1);
+                if (isLatitudeFirst(resultSet.getString(2))) {
+                    latitudeFirstSrids.add(srid);
+                }
+            }
+        } catch (SQLException e) {
+            log.debug("MySQL spatial reference axes are unavailable: {}", e.getMessage());
+        }
+        LATITUDE_FIRST_SRS_CACHE.putIfAbsent(connectionKey, Collections.unmodifiableSet(latitudeFirstSrids));
+    }
 
     @Override
     protected StringValueFCD fetchState(String columnName, ResultSet rs, ValueFetcherContext ctx) throws SQLException {
@@ -40,17 +104,21 @@ public class MyGeometryValueFetcher extends StringAsClobFetcher {
                 fcd = StringValueFCD.ofInMemory(true, 0, 0, null, null);
             } else {
                 try {
-                    int srid = ByteBuffer.wrap(geometryBytes, 0, 4).asIntBuffer().get();
+                    int srid = ByteBuffer.wrap(geometryBytes, 0, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
                     WKBReader wkbReader = new WKBReader(factory);
                     Geometry object = wkbReader.read(Arrays.copyOfRange(geometryBytes, 4, geometryBytes.length));
                     object.setSRID(srid);
+                    if (isLatitudeFirst(rs, srid)) {
+                        object.apply(SWAP_XY_FILTER);
+                        object.geometryChanged();
+                    }
 
                     String wkt = object.toText();
-                    byte[] wktBytes = wkt.getBytes();
+                    byte[] wktBytes = wkt.getBytes(StandardCharsets.UTF_8);
                     fcd = StringValueFCD.ofInMemory(true, wkt.length(), wkt.length(), wkt, wktBytes);
                 } catch (Exception e) {
                     String wkt = "WKB Error :" + e.getMessage();
-                    byte[] wktBytes = wkt.getBytes();
+                    byte[] wktBytes = wkt.getBytes(StandardCharsets.UTF_8);
                     fcd = StringValueFCD.ofInMemory(false, wkt.length(), wkt.length(), wkt, wktBytes);
                 }
             }
@@ -59,5 +127,53 @@ public class MyGeometryValueFetcher extends StringAsClobFetcher {
             fcd = (StringValueFCD) ctx.getContext();
         }
         return fcd;
+    }
+
+    private static boolean isLatitudeFirst(ResultSet resultSet, int srid) {
+        if (srid == 0) {
+            return false;
+        }
+        try {
+            String connectionKey = CONNECTION_KEYS.get(resultSet.getStatement().getConnection());
+            if (connectionKey == null) {
+                return false;
+            }
+            Set<Integer> latitudeFirstSrids = LATITUDE_FIRST_SRS_CACHE.get(connectionKey);
+            return latitudeFirstSrids != null && latitudeFirstSrids.contains(srid);
+        } catch (SQLException e) {
+            return false;
+        }
+    }
+
+    private static boolean isLatitudeFirst(String definition) {
+        if (definition == null) {
+            return false;
+        }
+        Matcher matcher = AXIS_DIRECTION.matcher(definition);
+        if (!matcher.find()) {
+            return false;
+        }
+        String firstDirection = matcher.group(1);
+        if (!matcher.find()) {
+            return false;
+        }
+        String secondDirection = matcher.group(1);
+        return isNorthSouth(firstDirection) && isEastWest(secondDirection);
+    }
+
+    private static boolean isNorthSouth(String direction) {
+        return "NORTH".equalsIgnoreCase(direction) || "SOUTH".equalsIgnoreCase(direction);
+    }
+
+    private static boolean isEastWest(String direction) {
+        return "EAST".equalsIgnoreCase(direction) || "WEST".equalsIgnoreCase(direction);
+    }
+
+    private static String connectionKey(Connection connection) {
+        try {
+            return connection.getMetaData().getURL() + '\0' + connection.getMetaData().getUserName();
+        } catch (SQLException e) {
+            return null;
+        }
     }
 }

--- a/backend/clouddm-plugins/clouddm-ds/dsc-common-mysql/src/main/java/com/clougence/clouddm/dsfamily/mysql/execute/fetcher/TimeStringValueFetcher.java
+++ b/backend/clouddm-plugins/clouddm-ds/dsc-common-mysql/src/main/java/com/clougence/clouddm/dsfamily/mysql/execute/fetcher/TimeStringValueFetcher.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.clougence.clouddm.dsfamily.mysql.execute.fetcher;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Locale;
+
+import com.clougence.clouddm.dsfamily.execute.fetcher.StringAsClobFetcher;
+import com.clougence.clouddm.sdk.execute.session.result.fetcher.ValueFetcherContext;
+
+public class TimeStringValueFetcher extends StringAsClobFetcher {
+
+    @Override
+    protected StringValueFCD fetchState(String columnName, ResultSet rs, ValueFetcherContext ctx) throws SQLException {
+        StringValueFCD fcd;
+        if (ctx.getContext() == null || !(ctx.getContext() instanceof StringValueFCD)) {
+            byte[] valueBytes = rs.getBytes(columnName);
+            if (valueBytes == null) {
+                fcd = StringValueFCD.ofInMemory(true, 0, 0, null, null);
+            } else {
+                String value = decodeTime(columnName, rs, valueBytes);
+                byte[] displayBytes = value.getBytes(StandardCharsets.UTF_8);
+                fcd = StringValueFCD.ofInMemory(true, value.length(), value.length(), value, displayBytes);
+            }
+            ctx.setContext(fcd);
+        } else {
+            fcd = (StringValueFCD) ctx.getContext();
+        }
+        return fcd;
+    }
+
+    private String decodeTime(String columnName, ResultSet rs, byte[] valueBytes) throws SQLException {
+        if (valueBytes.length != 0 && !isBinaryTime(valueBytes)) {
+            return new String(valueBytes, StandardCharsets.UTF_8);
+        }
+
+        boolean negative = valueBytes.length > 0 && valueBytes[0] != 0;
+        long days = valueBytes.length > 0 ? readUnsignedIntLittleEndian(valueBytes, 1) : 0;
+        long hours = days * 24 + (valueBytes.length > 0 ? Byte.toUnsignedInt(valueBytes[5]) : 0);
+        int minutes = valueBytes.length > 0 ? Byte.toUnsignedInt(valueBytes[6]) : 0;
+        int seconds = valueBytes.length > 0 ? Byte.toUnsignedInt(valueBytes[7]) : 0;
+        String value = String.format(Locale.ROOT, "%s%02d:%02d:%02d", negative ? "-" : "", hours, minutes, seconds);
+
+        int columnIndex = rs.findColumn(columnName);
+        int scale = rs.getMetaData().getScale(columnIndex);
+        if (scale == 0) {
+            int precision = rs.getMetaData().getPrecision(columnIndex);
+            scale = precision > 10 ? precision - 11 : 0;
+        }
+        if (scale > 0) {
+            long micros = valueBytes.length == 12 ? readUnsignedIntLittleEndian(valueBytes, 8) : 0;
+            String fraction = String.format(Locale.ROOT, "%06d", micros);
+            value += "." + fraction.substring(0, Math.min(scale, fraction.length()));
+        }
+        return value;
+    }
+
+    private boolean isBinaryTime(byte[] valueBytes) {
+        return (valueBytes.length == 8 || valueBytes.length == 12)
+                && (valueBytes[0] == 0 || valueBytes[0] == 1);
+    }
+
+    private long readUnsignedIntLittleEndian(byte[] valueBytes, int offset) {
+        return Integer.toUnsignedLong(Byte.toUnsignedInt(valueBytes[offset])
+                | Byte.toUnsignedInt(valueBytes[offset + 1]) << 8
+                | Byte.toUnsignedInt(valueBytes[offset + 2]) << 16
+                | Byte.toUnsignedInt(valueBytes[offset + 3]) << 24);
+    }
+}

--- a/backend/clouddm-plugins/clouddm-ds/dsc-common-mysql/src/main/java/com/clougence/clouddm/dsfamily/mysql/execute/fetcher/VectorValueFetcher.java
+++ b/backend/clouddm-plugins/clouddm-ds/dsc-common-mysql/src/main/java/com/clougence/clouddm/dsfamily/mysql/execute/fetcher/VectorValueFetcher.java
@@ -15,7 +15,8 @@
  */
 package com.clougence.clouddm.dsfamily.mysql.execute.fetcher;
 
-import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -23,17 +24,30 @@ import java.sql.SQLException;
 import com.clougence.clouddm.dsfamily.execute.fetcher.StringAsClobFetcher;
 import com.clougence.clouddm.sdk.execute.session.result.fetcher.ValueFetcherContext;
 
-public class BitValueFetcher extends StringAsClobFetcher {
+public class VectorValueFetcher extends StringAsClobFetcher {
 
     @Override
     protected StringValueFCD fetchState(String columnName, ResultSet rs, ValueFetcherContext ctx) throws SQLException {
         StringValueFCD fcd;
         if (ctx.getContext() == null || !(ctx.getContext() instanceof StringValueFCD)) {
-            byte[] bytes = rs.getBytes(columnName);
-            if (bytes == null) {
+            byte[] vectorBytes = rs.getBytes(columnName);
+            if (vectorBytes == null) {
                 fcd = StringValueFCD.ofInMemory(true, 0, 0, null, null);
+            } else if (vectorBytes.length % Float.BYTES != 0) {
+                throw new SQLException("Invalid VECTOR byte length: " + vectorBytes.length);
             } else {
-                String str = new BigInteger(1, bytes).toString(2);
+                ByteBuffer vectorBuffer = ByteBuffer.wrap(vectorBytes).order(ByteOrder.LITTLE_ENDIAN);
+                StringBuilder displayValue = new StringBuilder(vectorBytes.length + 2);
+                displayValue.append('[');
+                while (vectorBuffer.hasRemaining()) {
+                    if (displayValue.length() > 1) {
+                        displayValue.append(',');
+                    }
+                    displayValue.append(Float.toString(vectorBuffer.getFloat()));
+                }
+                displayValue.append(']');
+
+                String str = displayValue.toString();
                 byte[] displayBytes = str.getBytes(StandardCharsets.UTF_8);
                 fcd = StringValueFCD.ofInMemory(true, str.length(), str.length(), str, displayBytes);
             }

--- a/frontend/src/views/home/index.vue
+++ b/frontend/src/views/home/index.vue
@@ -57,7 +57,7 @@
         <a-button v-if="hasMoreData && !cellDetailLoading && !selectedCellDetail.error && !selectedCellDetail.mask" @click="handleLoadMoreCellData">
           {{ $t('jia-zai-geng-duo') }}
         </a-button>
-        <a-button type="primary" @click="handleDetailCopy">{{ $t('fu-zhi') }}</a-button>
+        <a-button type="primary" :loading="cellDetailLoading" @click="handleDetailCopy">{{ $t('fu-zhi') }}</a-button>
         <a-button @click="handleCloseCellDetailModal">{{ $t('guan-bi') }}</a-button>
       </template>
     </CCModal>
@@ -260,9 +260,53 @@ export default {
         }
       }
     },
-    handleDetailCopy() {
-      if (XEClipboard.copy(this.cellDetailContent)) {
+    async handleDetailCopy() {
+      if (this.cellDetailLoading) {
+        return;
+      }
+
+      let copyContent = this.cellDetailContent || '';
+      let moreSize = this.hasMoreData ? this.selectedCellDetail.moreSize || 0 : 0;
+      const { resultId, rowNumber, colNumber } = this.selectedCellDetail;
+      const fetchSize = 128 * 1024;
+
+      this.cellDetailLoading = true;
+      try {
+        while (moreSize > 0) {
+          const previousLength = copyContent.length;
+          const res = await this.$services.dmQueryFetchResultData({
+            data: {
+              resultId,
+              rowNumber,
+              colNumber,
+              offset: previousLength,
+              fetchSize
+            }
+          });
+          if (!res.success || !res.data) {
+            throw new Error(res.message || this.$t('jia-zai-shu-ju-shi-bai'));
+          }
+
+          const dataValue = res.data.value || res.data;
+          if (dataValue.error) {
+            throw new Error(this.$t('jia-zai-shu-ju-shi-bai'));
+          }
+
+          copyContent += dataValue.value || '';
+          moreSize = dataValue.moreSize || 0;
+          if (copyContent.length <= previousLength) {
+            throw new Error(this.$t('jia-zai-shu-ju-shi-bai'));
+          }
+        }
+        if (!XEClipboard.copy(copyContent)) {
+          throw new Error(this.$t('fu-zhi-shi-bai'));
+        }
         this.$Message.success(this.$t('fu-zhi-cheng-gong'));
+      } catch (error) {
+        appLogger.error(this.$t('fu-zhi-shi-bai'), error);
+        this.$Message.error(this.$t('fu-zhi-shi-bai'));
+      } finally {
+        this.cellDetailLoading = false;
       }
     },
     handleCloseCellDetailModal() {

--- a/tests/dbs/data-types/README.md
+++ b/tests/dbs/data-types/README.md
@@ -1,0 +1,57 @@
+# Data type acceptance assets
+
+This directory contains data-driven, repeatable acceptance assets for database
+types. The assets separate database facts from CloudDM presentation so a
+display problem is not confused with bad fixture data.
+
+## Contract
+
+Each datasource directory contains:
+
+- manifest.yaml: supported versions, complete type inventory, expected metadata,
+  reader path, display contract, and version exceptions.
+- setup.sql: idempotently recreates one explicitly named test schema and inserts
+  stable boundary data.
+- verify.sql: reports database-side facts without relying on CloudDM rendering.
+- cleanup.sql: removes only the explicitly named test schema.
+
+TEMPLATE.md defines the contract for adding another datasource. Browser
+acceptance is shared in tests/frontend/sql/datasource_type_display.md.
+
+## MySQL quick start
+
+Use a disposable MySQL instance. The checked-in arm64 database stack exposes
+MySQL 8.4 on localhost:2330.
+
+~~~bash
+cd tests/dbs/dbs_arm64
+docker compose up -d mysql
+
+docker compose exec -T mysql \
+  mysql --default-character-set=utf8mb4 -uroot -p123456 \
+  < ../data-types/mysql/setup.sql
+
+docker compose exec -T mysql \
+  mysql --default-character-set=utf8mb4 -uroot -p123456 \
+  < ../data-types/mysql/verify.sql
+~~~
+
+The setup script recreates only cdm_data_types. It conditionally creates JSON
+fixtures on MySQL 5.7+ and VECTOR fixtures on MySQL 9.0+; the repository's
+declared VECTOR acceptance target is MySQL 9.7.
+
+For the 4 MiB plus-one fixture, configure max_allowed_packet above 4194305.
+When the server packet limit is lower, setup.sql omits only that row and
+verify.sql reports the objective environment constraint instead of inserting
+corrupted empty data.
+
+To clean up:
+
+~~~bash
+docker compose exec -T mysql \
+  mysql --default-character-set=utf8mb4 -uroot -p123456 \
+  < ../data-types/mysql/cleanup.sql
+~~~
+
+Do not run setup.sql against an environment where a schema named
+cdm_data_types contains non-test data.

--- a/tests/dbs/data-types/TEMPLATE.md
+++ b/tests/dbs/data-types/TEMPLATE.md
@@ -1,0 +1,52 @@
+# Datasource data type template
+
+## Required files
+
+Create tests/dbs/data-types/<datasource>/ with manifest.yaml, setup.sql,
+verify.sql, and cleanup.sql.
+
+## Manifest requirements
+
+The manifest must record:
+
+- Exact product versions that are required, optional, unsupported, or blocked.
+- Every native type and alias, including modifiers that change range, precision,
+  encoding, timezone, or result representation.
+- The expected database-normalized metadata name, length, precision, scale,
+  unsigned flag, charset, collation, and nullability where applicable.
+- The CloudDM metadata type, ValueFetcher or equivalent reader, and the real
+  frontend rendering path.
+- Stable case identifiers and expected preview/full-content behavior.
+- Version gates and objective skip conditions.
+
+Aliases must not be silently omitted. If the database normalizes an alias,
+record both the declared spelling and the normalized metadata.
+
+## Fixture requirements
+
+- Use one clearly namespaced schema and table prefix.
+- setup.sql must be repeatable and must not touch objects outside that schema.
+- cleanup.sql must name the exact schema and contain no wildcard or dynamic
+  target.
+- Split tables by type family and use case_id on every fixture row.
+- Include NULL, EMPTY or ZERO, NORMAL, MIN, MAX, LONG, and product-specific
+  cases when meaningful.
+- Derive size boundaries from repository configuration or database contracts.
+- Keep destructive editor scenarios out of the first read-only acceptance pass.
+
+## Database truth requirements
+
+verify.sql must report:
+
+- VERSION, session timezone, charset, collation, and SQL mode.
+- information_schema metadata in a deterministic order.
+- Exact numeric text, HEX for bytes, normalized temporal text, JSON type/length,
+  and WKT plus SRID for spatial data.
+- Length and digest for long values instead of printing megabytes of content.
+- Feature availability for conditionally supported types.
+
+## Browser acceptance
+
+Use tests/frontend/sql/datasource_type_display.md. A datasource is PASS only
+when metadata, SQL results, and read-only table browsing pass together and no
+relevant HTTP, WebSocket, Console, or backend-log error is introduced.

--- a/tests/dbs/data-types/mysql/cleanup.sql
+++ b/tests/dbs/data-types/mysql/cleanup.sql
@@ -1,0 +1,2 @@
+-- Removes only the isolated acceptance schema.
+DROP DATABASE IF EXISTS cdm_data_types;

--- a/tests/dbs/data-types/mysql/manifest.yaml
+++ b/tests/dbs/data-types/mysql/manifest.yaml
@@ -1,0 +1,293 @@
+schema_version: 1
+datasource: MySQL
+fixture_schema: cdm_data_types
+table_prefix: cdm_dt_
+
+references:
+  declared_versions: backend/clouddm-plugins/clouddm-sql/sql-mysql/src/main/resources/META-INF/clougence/mysql-skip-permission-resources.json
+  metadata_types: backend/clouddm-utils/cg-schema/src/main/java/com/clougence/adapter/mysql/MySQLTypes.java
+  result_reader: backend/clouddm-plugins/clouddm-ds/dsc-common-mysql/src/main/java/com/clougence/clouddm/dsfamily/mysql/execute/MyColReader.java
+  result_file_reader: backend/clouddm-platform/cgdm-components/cg-com-results-file/src/main/java/com/clougence/clouddm/component/resultfile/ResultFileReader.java
+  frontend_renderer: frontend/src/views/sql/components/Result.vue
+  frontend_type_constants: frontend/src/views/sql/components/typeGroup.js
+  result_limits: backend/clouddm-platform/cgdm-console/src/main/java/com/clougence/clouddm/console/web/util/DmDsUtils.java
+
+versions:
+  - family: "5.6"
+    evidence_version: "5.6.51"
+    required: true
+    exceptions: [json, vector, geomcollection_alias]
+  - family: "5.7"
+    evidence_version: "5.7.44"
+    required: true
+    exceptions: [vector, geomcollection_alias]
+  - family: "8.0"
+    evidence_version: "8.0.46"
+    required: true
+    exceptions: [vector]
+  - family: "8.4"
+    evidence_version: "8.4.11"
+    required: true
+    primary_template: true
+    exceptions: [vector]
+  - family: "9.7"
+    evidence_version: "9.7.1"
+    required: true
+    exceptions: []
+
+feature_gates:
+  limit_plus_one_fixture:
+    minimum_max_allowed_packet: 4194306
+    setup_behavior: omitted with an explicit verify status when the server cannot generate a 4194305-byte value
+  geomcollection_alias:
+    minimum_version: "8.0"
+    setup_behavior: GEOMCOLLECTION alias column is added only on MySQL 8.0 or newer
+  json:
+    minimum_version: "5.7"
+    setup_behavior: created only when the server is MySQL 5.7 or newer
+  vector:
+    mysql_minimum_version: "9.0"
+    declared_acceptance_family: "9.7"
+    setup_behavior: created only when the server is MySQL 9.0 or newer
+
+cloud_limits:
+  preview_characters:
+    default: 256
+    boundaries: [255, 256, 257]
+  online_column_bytes:
+    default: 4194304
+    boundaries: [4194303, 4194304, 4194305]
+    fixture_precondition: max_allowed_packet must be greater than 4194305 for the plus-one row
+  intermediate_stream_boundary_bytes: 1048576
+
+acceptance_chains:
+  - metadata_object_tree
+  - sql_workbench_result
+  - read_only_table_browse
+
+required_observation_channels:
+  - visible_page
+  - http_status_and_business_result
+  - sql_websocket_terminal_state
+  - chrome_console_and_backend_log
+
+static_findings:
+  - id: MYSQL-AUDIT-001
+    severity_if_reproduced: P1
+    state: code_fixed_runtime_verified
+    finding: Connector/J exposes VECTOR as little-endian float bytes and rejects getString; MyColReader now maps it to VectorValueFetcher array text instead of Unsupported.
+  - id: MYSQL-AUDIT-002
+    severity_if_reproduced: P1
+    state: not_reproduced
+    finding: Connector/J 9.6 normalizes every tested spatial result column to columnTypeName GEOMETRY, so all declarations select MyGeometryValueFetcher.
+  - id: MYSQL-AUDIT-003
+    severity_if_reproduced: P2
+    state: informational
+    finding: mysqlTypeGroup omits MULTI spatial types but currently has no consumer; Result.vue renders all values through the same pre element.
+  - id: MYSQL-AUDIT-004
+    severity_if_reproduced: P1
+    state: code_fixed_runtime_verified
+    finding: Connector/J returns BIT(64) max from getString as -1; BitValueFetcher now converts the unsigned raw bytes to base-2 text.
+  - id: MYSQL-AUDIT-005
+    severity_if_reproduced: P1
+    state: code_fixed_runtime_verified
+    finding: Generic TIME conversion dropped the sign and corrupted MySQL duration values; TIME now uses TimeStringValueFetcher over the raw JDBC bytes.
+  - id: MYSQL-AUDIT-006
+    severity_if_reproduced: P1
+    state: code_fixed_runtime_verified
+    finding: Geographic internal WKB uses longitude-latitude storage order and the SRID header is little-endian; MyGeometryValueFetcher now restores SRS-defined latitude-first axes when required.
+  - id: MYSQL-AUDIT-007
+    severity_if_reproduced: P1
+    state: code_fixed_runtime_verified
+    finding: BLOB detail paging mixed raw-byte sizes with hexadecimal-character offsets and stopped halfway; binary result metadata and detail ranges now consistently use hexadecimal character units.
+  - id: MYSQL-AUDIT-008
+    severity_if_reproduced: P1
+    state: code_fixed_runtime_verified
+    finding: Detail copy previously copied only the currently loaded chunks; it now loads every available remaining chunk before copying.
+  - id: MYSQL-AUDIT-009
+    severity_if_reproduced: P1
+    state: code_fixed_runtime_verified
+    finding: Full-mode table browsing failed because DsDataEditorServiceImpl did not inject DmDsConfigService; the dependency is now injected and the read-only editor opens normally.
+  - id: MYSQL-AUDIT-010
+    severity_if_reproduced: P1
+    state: code_fixed_runtime_verified
+    finding: Full-mode table browsing rejected the current ResultSetMeta plus ResultSet protocol; the editor now combines the split messages into one EditorResultSet.
+  - id: MYSQL-AUDIT-011
+    severity_if_reproduced: P1
+    state: code_fixed_runtime_verified
+    finding: Connector/J 8.4 cannot decode MySQL 9 VECTOR protocol type 242 in binary server-prepared results; MySQL 9 sessions on Connector/J 8 now use client-prepared text results so VectorValueFetcher receives the raw bytes.
+
+type_families:
+  - family: bit_and_integer
+    table: cdm_dt_numeric
+    cases: [NULL, ZERO, NORMAL, MIN, MAX]
+    types:
+      - declaration: BIT(64)
+        aliases: []
+        metadata_type: BIT
+        reader_by_column_type_name: BitValueFetcher
+        expected_display: unsigned base-2 text
+      - declaration: TINYINT
+        aliases: [BOOL, BOOLEAN]
+        metadata_type: TINYINT
+        reader_by_column_type_name: ByteValueFetcher
+        expected_display: exact signed decimal
+      - declaration: TINYINT UNSIGNED
+        aliases: []
+        metadata_type: TINYINT
+        reader_by_column_type_name: ShortValueFetcher
+        expected_display: exact unsigned decimal
+      - declaration: SMALLINT
+        aliases: []
+        metadata_type: SMALLINT
+        reader_by_column_type_name: ShortValueFetcher
+        expected_display: exact signed decimal
+      - declaration: SMALLINT UNSIGNED
+        aliases: []
+        metadata_type: SMALLINT
+        reader_by_column_type_name: IntegerValueFetcher
+        expected_display: exact unsigned decimal
+      - declaration: MEDIUMINT
+        aliases: []
+        metadata_type: MEDIUMINT
+        reader_by_column_type_name: IntegerValueFetcher
+        expected_display: exact signed decimal
+      - declaration: MEDIUMINT UNSIGNED
+        aliases: []
+        metadata_type: MEDIUMINT
+        reader_by_column_type_name: IntegerValueFetcher
+        expected_display: exact unsigned decimal
+      - declaration: INT
+        aliases: [INTEGER]
+        metadata_type: INT
+        reader_by_column_type_name: IntegerValueFetcher
+        expected_display: exact signed decimal
+      - declaration: INT UNSIGNED
+        aliases: [INTEGER UNSIGNED]
+        metadata_type: INT
+        reader_by_column_type_name: LongValueFetcher
+        expected_display: exact unsigned decimal
+      - declaration: BIGINT
+        aliases: []
+        metadata_type: BIGINT
+        reader_by_column_type_name: LongValueFetcher
+        expected_display: exact signed decimal
+      - declaration: BIGINT UNSIGNED
+        aliases: [SERIAL]
+        metadata_type: BIGINT
+        reader_by_column_type_name: BigIntegerValueFetcher
+        expected_display: exact unsigned decimal without JavaScript precision loss
+
+  - family: fixed_and_floating
+    table: cdm_dt_numeric
+    cases: [NULL, ZERO, NORMAL, MIN, MAX]
+    types:
+      - declaration: DECIMAL(65,30)
+        aliases: [DEC, NUMERIC, FIXED]
+        metadata_type: DECIMAL
+        reader_by_column_type_name: StringValueFetcher
+        expected_display: exact plain decimal with scale preserved by database output
+      - declaration: FLOAT
+        aliases: []
+        metadata_type: FLOAT
+        reader_by_column_type_name: FloatValueFetcher
+        expected_display: Connector/J single-precision value
+      - declaration: FLOAT UNSIGNED
+        aliases: []
+        metadata_type: FLOAT
+        reader_by_column_type_name: DoubleValueFetcher
+        expected_display: Connector/J approximate value
+      - declaration: DOUBLE
+        aliases: [DOUBLE PRECISION, REAL]
+        metadata_type: DOUBLE
+        reader_by_column_type_name: DoubleValueFetcher
+        expected_display: Connector/J double-precision value
+
+  - family: temporal
+    table: cdm_dt_temporal
+    cases: [NULL, ZERO, NORMAL, MIN, MAX, NEGATIVE_TIME]
+    types:
+      - { declaration: DATE, metadata_type: DATE, reader_by_column_type_name: StringValueFetcher }
+      - { declaration: TIME, metadata_type: TIME, reader_by_column_type_name: TimeStringValueFetcher }
+      - { declaration: TIME(6), metadata_type: TIME, reader_by_column_type_name: TimeStringValueFetcher }
+      - { declaration: DATETIME, metadata_type: DATETIME, reader_by_column_type_name: StringValueFetcher }
+      - { declaration: DATETIME(6), metadata_type: DATETIME, reader_by_column_type_name: StringValueFetcher }
+      - { declaration: TIMESTAMP, metadata_type: TIMESTAMP, reader_by_column_type_name: StringValueFetcher }
+      - { declaration: TIMESTAMP(6), metadata_type: TIMESTAMP, reader_by_column_type_name: StringValueFetcher }
+      - { declaration: YEAR, metadata_type: YEAR, reader_by_column_type_name: ShortValueFetcher }
+
+  - family: character
+    table: cdm_dt_character
+    cases: [NULL, EMPTY, NORMAL, UNICODE, BOUNDARY]
+    types:
+      - { declaration: CHAR(16), metadata_type: CHAR, reader_by_column_type_name: StringValueFetcher }
+      - { declaration: VARCHAR(1024), metadata_type: VARCHAR, reader_by_column_type_name: StringValueFetcher }
+      - { declaration: TINYTEXT, metadata_type: TINYTEXT, reader_by_column_type_name: StringValueFetcher }
+      - { declaration: TEXT, metadata_type: TEXT, reader_by_column_type_name: StringValueFetcher }
+      - { declaration: MEDIUMTEXT, metadata_type: MEDIUMTEXT, reader_by_column_type_name: StringAsClobFetcher }
+      - { declaration: LONGTEXT, metadata_type: LONGTEXT, reader_by_column_type_name: StringAsClobFetcher }
+      - { declaration: ENUM, metadata_type: ENUM, reader_by_column_type_name: StringValueFetcher }
+      - { declaration: SET, metadata_type: SET, reader_by_column_type_name: StringValueFetcher }
+
+  - family: binary_and_lob
+    table: cdm_dt_binary_lob
+    cases: [NULL, EMPTY, BYTES, BOUNDARY_256, BOUNDARY_257, ONE_MIB]
+    expected_display: uppercase hexadecimal text, with NULL distinct from an empty byte string
+    types:
+      - { declaration: BINARY(8), metadata_type: BINARY, reader_by_column_type_name: BytesValueFetcher }
+      - { declaration: VARBINARY(257), metadata_type: VARBINARY, reader_by_column_type_name: BytesValueFetcher }
+      - { declaration: TINYBLOB, metadata_type: TINYBLOB, reader_by_column_type_name: BytesValueFetcher }
+      - { declaration: BLOB, metadata_type: BLOB, reader_by_column_type_name: BytesValueFetcher }
+      - { declaration: MEDIUMBLOB, metadata_type: MEDIUMBLOB, reader_by_column_type_name: BytesAsStreamFetcher }
+      - { declaration: LONGBLOB, metadata_type: LONGBLOB, reader_by_column_type_name: BytesAsStreamFetcher }
+
+  - family: json
+    table: cdm_dt_json
+    minimum_version: "5.7"
+    cases: [SQL_NULL, JSON_NULL, SCALAR, OBJECT, ARRAY, DEEP, UNICODE, LONG]
+    types:
+      - declaration: JSON
+        metadata_type: JSON
+        reader_by_column_type_name: StringAsClobFetcher
+        expected_display: valid database-normalized JSON text
+
+  - family: spatial
+    table: cdm_dt_spatial
+    cases: [NULL, SRID_0, SRID_4326]
+    expected_display: valid WKT in the SRS-defined axis order used by ST_AsText, without binary garbage or WKB Error
+    types:
+      - { declaration: GEOMETRY, metadata_type: GEOMETRY, reader_by_column_type_name: MyGeometryValueFetcher }
+      - { declaration: POINT, metadata_type: POINT, reader_by_column_type_name: MyGeometryValueFetcher }
+      - { declaration: LINESTRING, metadata_type: LINESTRING, reader_by_column_type_name: MyGeometryValueFetcher }
+      - { declaration: POLYGON, metadata_type: POLYGON, reader_by_column_type_name: MyGeometryValueFetcher }
+      - { declaration: MULTIPOINT, metadata_type: MULTIPOINT, reader_by_column_type_name: MyGeometryValueFetcher }
+      - { declaration: MULTILINESTRING, metadata_type: MULTILINESTRING, reader_by_column_type_name: MyGeometryValueFetcher }
+      - { declaration: MULTIPOLYGON, metadata_type: MULTIPOLYGON, reader_by_column_type_name: MyGeometryValueFetcher }
+      - { declaration: GEOMETRYCOLLECTION, metadata_type: GEOMETRY_COLLECTION, reader_by_column_type_name: MyGeometryValueFetcher }
+      - { declaration: GEOMCOLLECTION, minimum_version: "8.0", metadata_type: GEOM_COLLECTION, reader_by_column_type_name: MyGeometryValueFetcher }
+
+  - family: vector
+    table: cdm_dt_vector
+    mysql_minimum_version: "9.0"
+    declared_acceptance_family: "9.7"
+    cases: [NULL, ONE_DIMENSION, NORMAL, LONG]
+    types:
+      - declaration: VECTOR(N)
+        metadata_type: VECTOR
+        reader_by_column_type_name: VectorValueFetcher
+        required_display_contract: numeric-equivalent array text
+
+frontend_contract:
+  renderer: Result.vue bodyCell
+  null_display: italic NULL
+  non_null_display: preformatted text
+  long_value_contract:
+    preview: first configured display characters with incomplete marker
+    detail: fetches all remaining chunks within the column byte limit
+    copy: fetches every available remaining cached chunk before writing to clipboard
+  prohibited_values:
+    - Unsupported
+    - undefined
+    - "[object Object]"
+    - WKB Error
+    - binary replacement characters for spatial values

--- a/tests/dbs/data-types/mysql/setup.sql
+++ b/tests/dbs/data-types/mysql/setup.sql
@@ -1,0 +1,443 @@
+-- Recreates only the isolated cdm_data_types acceptance schema.
+-- Run with a client that supports DELIMITER, such as mysql.
+
+SET NAMES utf8mb4;
+SET @cdm_saved_sql_mode = @@SESSION.sql_mode;
+SET @cdm_saved_time_zone = @@SESSION.time_zone;
+SET SESSION sql_mode = '';
+SET SESSION time_zone = '+00:00';
+
+DROP DATABASE IF EXISTS cdm_data_types;
+CREATE DATABASE cdm_data_types
+  CHARACTER SET utf8mb4
+  COLLATE utf8mb4_unicode_ci;
+USE cdm_data_types;
+
+CREATE TABLE cdm_dt_numeric (
+  case_id VARCHAR(32) NOT NULL PRIMARY KEY,
+  c_bit BIT(64) NULL,
+  c_tinyint TINYINT NULL,
+  c_tinyint_unsigned TINYINT UNSIGNED NULL,
+  c_smallint SMALLINT NULL,
+  c_smallint_unsigned SMALLINT UNSIGNED NULL,
+  c_mediumint MEDIUMINT NULL,
+  c_mediumint_unsigned MEDIUMINT UNSIGNED NULL,
+  c_int INT NULL,
+  c_integer INTEGER NULL,
+  c_int_unsigned INT UNSIGNED NULL,
+  c_integer_unsigned INTEGER UNSIGNED NULL,
+  c_bigint BIGINT NULL,
+  c_bigint_unsigned BIGINT UNSIGNED NULL,
+  c_decimal DECIMAL(65,30) NULL,
+  c_dec DEC(20,5) NULL,
+  c_numeric NUMERIC(30,10) NULL,
+  c_fixed FIXED(20,5) NULL,
+  c_float FLOAT NULL,
+  c_float_unsigned FLOAT UNSIGNED NULL,
+  c_double DOUBLE NULL,
+  c_double_precision DOUBLE PRECISION NULL,
+  c_real REAL NULL
+) ENGINE=InnoDB;
+
+INSERT INTO cdm_dt_numeric (case_id) VALUES ('NULL');
+
+INSERT INTO cdm_dt_numeric VALUES (
+  'ZERO',
+  b'0',
+  0, 0,
+  0, 0,
+  0, 0,
+  0, 0, 0, 0,
+  0, 0,
+  0, 0, 0, 0,
+  0, 0,
+  0, 0, 0
+);
+
+INSERT INTO cdm_dt_numeric VALUES (
+  'NORMAL',
+  b'101010',
+  -42, 200,
+  -12345, 54321,
+  -456789, 12345678,
+  -123456789, 123456789, 4000000000, 3000000000,
+  -9007199254740993, 18014398509481987,
+  12345.678901234567890123456789012345,
+  123456789012345.12345,
+  12345678901234567890.1234567890,
+  123456789012345.54321,
+  -12345.125, 12345.125,
+  -1234567890.1234567,
+  1234567890.7654321,
+  -9876543210.125
+);
+
+INSERT INTO cdm_dt_numeric VALUES (
+  'MIN',
+  b'0',
+  -128, 0,
+  -32768, 0,
+  -8388608, 0,
+  -2147483648, -2147483648, 0, 0,
+  -9223372036854775808, 0,
+  -99999999999999999999999999999999999.999999999999999999999999999999,
+  -999999999999999.99999,
+  -99999999999999999999.9999999999,
+  -999999999999999.99999,
+  -3.4028234E+38, 0,
+  -1.7976931348623155E+308,
+  -1.7976931348623155E+308,
+  -1.7976931348623155E+308
+);
+
+INSERT INTO cdm_dt_numeric VALUES (
+  'MAX',
+  b'1111111111111111111111111111111111111111111111111111111111111111',
+  127, 255,
+  32767, 65535,
+  8388607, 16777215,
+  2147483647, 2147483647, 4294967295, 4294967295,
+  9223372036854775807, 18446744073709551615,
+  99999999999999999999999999999999999.999999999999999999999999999999,
+  999999999999999.99999,
+  99999999999999999999.9999999999,
+  999999999999999.99999,
+  3.4028234E+38, 3.4028234E+38,
+  1.7976931348623155E+308,
+  1.7976931348623155E+308,
+  1.7976931348623155E+308
+);
+
+CREATE TABLE cdm_dt_alias (
+  serial_value SERIAL,
+  case_id VARCHAR(32) NOT NULL,
+  c_bool BOOL NULL,
+  c_boolean BOOLEAN NULL,
+  UNIQUE KEY uk_cdm_dt_alias_case (case_id)
+) ENGINE=InnoDB;
+
+INSERT INTO cdm_dt_alias (case_id, c_bool, c_boolean) VALUES
+  ('ZERO', 0, 0),
+  ('NORMAL', 1, -7),
+  ('NULL', NULL, NULL);
+
+CREATE TABLE cdm_dt_temporal (
+  case_id VARCHAR(32) NOT NULL PRIMARY KEY,
+  c_date DATE NULL,
+  c_time0 TIME NULL,
+  c_time6 TIME(6) NULL,
+  c_datetime0 DATETIME NULL,
+  c_datetime6 DATETIME(6) NULL,
+  c_timestamp0 TIMESTAMP NULL,
+  c_timestamp6 TIMESTAMP(6) NULL,
+  c_year YEAR NULL
+) ENGINE=InnoDB;
+
+INSERT INTO cdm_dt_temporal (case_id) VALUES ('NULL');
+INSERT INTO cdm_dt_temporal VALUES (
+  'ZERO',
+  '0000-00-00',
+  '00:00:00',
+  '00:00:00.000000',
+  '0000-00-00 00:00:00',
+  '0000-00-00 00:00:00.000000',
+  '0000-00-00 00:00:00',
+  '0000-00-00 00:00:00.000000',
+  0
+);
+INSERT INTO cdm_dt_temporal VALUES (
+  'NORMAL',
+  '2024-02-29',
+  '12:34:56',
+  '12:34:56.123456',
+  '2024-02-29 12:34:56',
+  '2024-02-29 12:34:56.123456',
+  '2024-02-29 12:34:56',
+  '2024-02-29 12:34:56.123456',
+  2024
+);
+INSERT INTO cdm_dt_temporal VALUES (
+  'MIN',
+  '1000-01-01',
+  '-838:59:59',
+  '-838:59:59.000000',
+  '1000-01-01 00:00:00',
+  '1000-01-01 00:00:00.000000',
+  '1971-01-01 00:00:01',
+  '1971-01-01 00:00:01.000000',
+  1901
+);
+INSERT INTO cdm_dt_temporal VALUES (
+  'MAX',
+  '9999-12-31',
+  '838:59:59',
+  '838:59:59.000000',
+  '9999-12-31 23:59:59',
+  '9999-12-31 23:59:59.999999',
+  '2038-01-19 03:14:07',
+  '2038-01-19 03:14:07.499999',
+  2155
+);
+INSERT INTO cdm_dt_temporal (
+  case_id,
+  c_time0,
+  c_time6
+) VALUES (
+  'NEGATIVE_TIME',
+  '-12:34:56',
+  '-12:34:56.123456'
+);
+
+CREATE TABLE cdm_dt_character (
+  case_id VARCHAR(32) NOT NULL PRIMARY KEY,
+  c_char CHAR(16) NULL,
+  c_varchar VARCHAR(1024) NULL,
+  c_tinytext TINYTEXT NULL,
+  c_text TEXT NULL,
+  c_mediumtext MEDIUMTEXT NULL,
+  c_longtext LONGTEXT NULL,
+  c_enum ENUM('', 'alpha', '中文', 'emoji😀') NULL,
+  c_set SET('alpha', 'beta', '中文', 'emoji😀') NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO cdm_dt_character (case_id) VALUES ('NULL');
+INSERT INTO cdm_dt_character VALUES (
+  'EMPTY',
+  '', '', '', '', '', '', '', ''
+);
+INSERT INTO cdm_dt_character VALUES (
+  'NORMAL',
+  'trail  ',
+  CONCAT('quote '' slash \\', CHAR(10), 'line2'),
+  'tiny text',
+  CONCAT('line1', CHAR(10), 'line2'),
+  'medium text',
+  'long text',
+  'alpha',
+  'alpha,beta'
+);
+INSERT INTO cdm_dt_character VALUES (
+  'UNICODE',
+  '中文',
+  '中文😀é',
+  '中文😀',
+  CONCAT('组合字符 é', CHAR(10), 'emoji 😀'),
+  '多语言 Καλημέρα مرحبا',
+  '中文😀é',
+  'emoji😀',
+  '中文,emoji😀'
+);
+INSERT INTO cdm_dt_character VALUES (
+  'BOUNDARY',
+  '1234567890123456',
+  REPEAT('v', 257),
+  REPEAT('t', 255),
+  REPEAT('x', 257),
+  REPEAT('m', 1024),
+  REPEAT('l', 1024),
+  '中文',
+  'beta'
+);
+
+CREATE TABLE cdm_dt_character_long (
+  case_id VARCHAR(32) NOT NULL PRIMARY KEY,
+  c_longtext LONGTEXT NOT NULL,
+  expected_characters INT UNSIGNED NOT NULL,
+  expected_bytes INT UNSIGNED NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO cdm_dt_character_long VALUES
+  ('CHARS_255', REPEAT('a', 255), 255, 255),
+  ('CHARS_256', REPEAT('b', 256), 256, 256),
+  ('CHARS_257', REPEAT('c', 257), 257, 257),
+  ('ONE_MIB', REPEAT('d', 1048576), 1048576, 1048576),
+  ('LIMIT_MINUS_ONE', REPEAT('e', 4194303), 4194303, 4194303),
+  ('LIMIT_EXACT', REPEAT('f', 4194304), 4194304, 4194304);
+
+CREATE TABLE cdm_dt_binary_lob (
+  case_id VARCHAR(32) NOT NULL PRIMARY KEY,
+  c_binary BINARY(8) NULL,
+  c_varbinary VARBINARY(257) NULL,
+  c_tinyblob TINYBLOB NULL,
+  c_blob BLOB NULL,
+  c_mediumblob MEDIUMBLOB NULL,
+  c_longblob LONGBLOB NULL
+) ENGINE=InnoDB;
+
+INSERT INTO cdm_dt_binary_lob (case_id) VALUES ('NULL');
+INSERT INTO cdm_dt_binary_lob VALUES (
+  'EMPTY',
+  X'', X'', X'', X'', X'', X''
+);
+INSERT INTO cdm_dt_binary_lob VALUES (
+  'BYTES',
+  X'00FF010203040506',
+  X'00FF7F80',
+  X'00FF',
+  X'0001027F80FEFF',
+  X'00FF',
+  X'00FF'
+);
+INSERT INTO cdm_dt_binary_lob VALUES (
+  'BOUNDARY_256',
+  X'0102030405060708',
+  REPEAT(UNHEX('A1'), 256),
+  REPEAT(UNHEX('A2'), 255),
+  REPEAT(UNHEX('A3'), 256),
+  REPEAT(UNHEX('A4'), 256),
+  REPEAT(UNHEX('A5'), 256)
+);
+INSERT INTO cdm_dt_binary_lob VALUES (
+  'BOUNDARY_257',
+  X'0807060504030201',
+  REPEAT(UNHEX('B1'), 257),
+  REPEAT(UNHEX('B2'), 255),
+  REPEAT(UNHEX('B3'), 257),
+  REPEAT(UNHEX('B4'), 257),
+  REPEAT(UNHEX('B5'), 257)
+);
+INSERT INTO cdm_dt_binary_lob (
+  case_id,
+  c_mediumblob,
+  c_longblob
+) VALUES (
+  'ONE_MIB',
+  REPEAT(UNHEX('C4'), 1048576),
+  REPEAT(UNHEX('C5'), 1048576)
+);
+
+CREATE TABLE cdm_dt_binary_long (
+  case_id VARCHAR(32) NOT NULL PRIMARY KEY,
+  c_longblob LONGBLOB NOT NULL,
+  expected_bytes INT UNSIGNED NOT NULL
+) ENGINE=InnoDB;
+
+INSERT INTO cdm_dt_binary_long VALUES
+  ('BYTES_255', REPEAT(UNHEX('D1'), 255), 255),
+  ('BYTES_256', REPEAT(UNHEX('D2'), 256), 256),
+  ('BYTES_257', REPEAT(UNHEX('D3'), 257), 257),
+  ('ONE_MIB', REPEAT(UNHEX('D4'), 1048576), 1048576),
+  ('LIMIT_MINUS_ONE', REPEAT(UNHEX('D5'), 4194303), 4194303),
+  ('LIMIT_EXACT', REPEAT(UNHEX('D6'), 4194304), 4194304);
+
+CREATE TABLE cdm_dt_spatial (
+  case_id VARCHAR(32) NOT NULL PRIMARY KEY,
+  c_geometry GEOMETRY NULL,
+  c_point POINT NULL,
+  c_linestring LINESTRING NULL,
+  c_polygon POLYGON NULL,
+  c_multipoint MULTIPOINT NULL,
+  c_multilinestring MULTILINESTRING NULL,
+  c_multipolygon MULTIPOLYGON NULL,
+  c_geometrycollection GEOMETRYCOLLECTION NULL
+) ENGINE=InnoDB;
+
+INSERT INTO cdm_dt_spatial (case_id) VALUES ('NULL');
+INSERT INTO cdm_dt_spatial VALUES (
+  'SRID_0',
+  ST_GeomFromText('POINT(1 2)', 0),
+  ST_GeomFromText('POINT(1 2)', 0),
+  ST_GeomFromText('LINESTRING(0 0,1 1,2 1)', 0),
+  ST_GeomFromText('POLYGON((0 0,0 2,2 2,2 0,0 0))', 0),
+  ST_GeomFromText('MULTIPOINT((1 1),(2 2))', 0),
+  ST_GeomFromText('MULTILINESTRING((0 0,1 1),(2 2,3 3))', 0),
+  ST_GeomFromText('MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)))', 0),
+  ST_GeomFromText('GEOMETRYCOLLECTION(POINT(1 1),LINESTRING(0 0,1 1))', 0)
+);
+INSERT INTO cdm_dt_spatial VALUES (
+  'SRID_4326',
+  ST_GeomFromText('POINT(30 120)', 4326),
+  ST_GeomFromText('POINT(30 120)', 4326),
+  ST_GeomFromText('LINESTRING(0 0,1 1,2 1)', 4326),
+  ST_GeomFromText('POLYGON((0 0,0 2,2 2,2 0,0 0))', 4326),
+  ST_GeomFromText('MULTIPOINT((1 1),(2 2))', 4326),
+  ST_GeomFromText('MULTILINESTRING((0 0,1 1),(2 2,3 3))', 4326),
+  ST_GeomFromText('MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)))', 4326),
+  ST_GeomFromText('GEOMETRYCOLLECTION(POINT(1 1),LINESTRING(0 0,1 1))', 4326)
+);
+
+DELIMITER $$
+CREATE PROCEDURE cdm_setup_optional_types()
+BEGIN
+  DECLARE cdm_major INT DEFAULT 0;
+  DECLARE cdm_minor INT DEFAULT 0;
+
+  SET cdm_major = CAST(SUBSTRING_INDEX(VERSION(), '.', 1) AS UNSIGNED);
+  SET cdm_minor = CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(VERSION(), '.', 2), '.', -1) AS UNSIGNED);
+
+  IF @@max_allowed_packet > 4194305 THEN
+    INSERT INTO cdm_dt_character_long VALUES
+      ('LIMIT_PLUS_ONE', REPEAT('g', 4194305), 4194305, 4194305);
+    INSERT INTO cdm_dt_binary_long VALUES
+      ('LIMIT_PLUS_ONE', REPEAT(UNHEX('D7'), 4194305), 4194305);
+  END IF;
+
+  IF cdm_major >= 8 THEN
+    SET @cdm_sql = 'ALTER TABLE cdm_dt_spatial
+      ADD COLUMN c_geomcollection GEOMCOLLECTION NULL';
+    PREPARE cdm_stmt FROM @cdm_sql;
+    EXECUTE cdm_stmt;
+    DEALLOCATE PREPARE cdm_stmt;
+
+    SET @cdm_sql = 'UPDATE cdm_dt_spatial
+      SET c_geomcollection = ST_GeomFromText(''GEOMETRYCOLLECTION()'',
+        CASE case_id WHEN ''SRID_4326'' THEN 4326 ELSE 0 END)
+      WHERE case_id IN (''SRID_0'', ''SRID_4326'')';
+    PREPARE cdm_stmt FROM @cdm_sql;
+    EXECUTE cdm_stmt;
+    DEALLOCATE PREPARE cdm_stmt;
+  END IF;
+
+  IF cdm_major > 5 OR (cdm_major = 5 AND cdm_minor >= 7) THEN
+    SET @cdm_sql = 'CREATE TABLE cdm_dt_json (
+      case_id VARCHAR(32) NOT NULL PRIMARY KEY,
+      c_json JSON NULL
+    ) ENGINE=InnoDB';
+    PREPARE cdm_stmt FROM @cdm_sql;
+    EXECUTE cdm_stmt;
+    DEALLOCATE PREPARE cdm_stmt;
+
+    SET @cdm_sql = 'INSERT INTO cdm_dt_json VALUES
+      (''SQL_NULL'', NULL),
+      (''JSON_NULL'', ''null''),
+      (''SCALAR'', ''123.456''),
+      (''OBJECT'', ''{"ascii":"alpha","number":123,"boolean":true}''),
+      (''ARRAY'', ''[1,"two",null,true]''),
+      (''DEEP'', ''{"l1":{"l2":{"l3":{"value":"deep"}}}}''),
+      (''UNICODE'', ''{"text":"中文😀","combining":"é"}''),
+      (''LONG'', CONCAT(''{"payload":"'',
+        REPEAT(''j'', 1024), ''"}''))';
+    PREPARE cdm_stmt FROM @cdm_sql;
+    EXECUTE cdm_stmt;
+    DEALLOCATE PREPARE cdm_stmt;
+  END IF;
+
+  IF cdm_major >= 9 THEN
+    SET @cdm_sql = 'CREATE TABLE cdm_dt_vector (
+      case_id VARCHAR(32) NOT NULL PRIMARY KEY,
+      c_vector_1 VECTOR(1) NULL,
+      c_vector_3 VECTOR(3) NULL,
+      c_vector_1024 VECTOR(1024) NULL
+    ) ENGINE=InnoDB';
+    PREPARE cdm_stmt FROM @cdm_sql;
+    EXECUTE cdm_stmt;
+    DEALLOCATE PREPARE cdm_stmt;
+
+    SET @cdm_sql = 'INSERT INTO cdm_dt_vector VALUES
+      (''NULL'', NULL, NULL, NULL),
+      (''ONE_DIMENSION'', STRING_TO_VECTOR(''[1.5]''), NULL, NULL),
+      (''NORMAL'', NULL, STRING_TO_VECTOR(''[1.0,-2.5,3.25]''), NULL),
+      (''LONG'', NULL, NULL,
+        STRING_TO_VECTOR(CONCAT(''['', REPEAT(''1,'', 1023), ''1]'')))';
+    PREPARE cdm_stmt FROM @cdm_sql;
+    EXECUTE cdm_stmt;
+    DEALLOCATE PREPARE cdm_stmt;
+  END IF;
+END$$
+DELIMITER ;
+
+CALL cdm_setup_optional_types();
+DROP PROCEDURE cdm_setup_optional_types;
+
+SET SESSION time_zone = @cdm_saved_time_zone;
+SET SESSION sql_mode = @cdm_saved_sql_mode;

--- a/tests/dbs/data-types/mysql/verify.sql
+++ b/tests/dbs/data-types/mysql/verify.sql
@@ -1,0 +1,271 @@
+-- Reports source-database facts. Large values are represented by length and SHA-256.
+
+SET NAMES utf8mb4;
+SET @cdm_saved_time_zone = @@SESSION.time_zone;
+SET SESSION time_zone = '+00:00';
+USE cdm_data_types;
+
+SELECT
+  'ENVIRONMENT' AS section_name,
+  VERSION() AS server_version,
+  @@SESSION.time_zone AS session_time_zone,
+  @@SESSION.sql_mode AS session_sql_mode,
+  @@character_set_connection AS connection_charset,
+  @@collation_connection AS connection_collation,
+  @@max_allowed_packet AS max_allowed_packet;
+
+SELECT
+  'METADATA' AS section_name,
+  table_name,
+  ordinal_position,
+  column_name,
+  data_type,
+  column_type,
+  character_maximum_length,
+  character_octet_length,
+  numeric_precision,
+  numeric_scale,
+  datetime_precision,
+  character_set_name,
+  collation_name,
+  is_nullable,
+  column_default,
+  extra
+FROM information_schema.columns
+WHERE table_schema = 'cdm_data_types'
+ORDER BY table_name, ordinal_position;
+
+SELECT
+  'NUMERIC' AS section_name,
+  case_id,
+  BIN(c_bit) AS c_bit_bin,
+  CAST(c_tinyint AS CHAR) AS c_tinyint,
+  CAST(c_tinyint_unsigned AS CHAR) AS c_tinyint_unsigned,
+  CAST(c_smallint AS CHAR) AS c_smallint,
+  CAST(c_smallint_unsigned AS CHAR) AS c_smallint_unsigned,
+  CAST(c_mediumint AS CHAR) AS c_mediumint,
+  CAST(c_mediumint_unsigned AS CHAR) AS c_mediumint_unsigned,
+  CAST(c_int AS CHAR) AS c_int,
+  CAST(c_integer AS CHAR) AS c_integer,
+  CAST(c_int_unsigned AS CHAR) AS c_int_unsigned,
+  CAST(c_integer_unsigned AS CHAR) AS c_integer_unsigned,
+  CAST(c_bigint AS CHAR) AS c_bigint,
+  CAST(c_bigint_unsigned AS CHAR) AS c_bigint_unsigned,
+  CAST(c_decimal AS CHAR) AS c_decimal,
+  CAST(c_dec AS CHAR) AS c_dec,
+  CAST(c_numeric AS CHAR) AS c_numeric,
+  CAST(c_fixed AS CHAR) AS c_fixed,
+  CAST(c_float AS CHAR) AS c_float,
+  CAST(c_float_unsigned AS CHAR) AS c_float_unsigned,
+  CAST(c_double AS CHAR) AS c_double,
+  CAST(c_double_precision AS CHAR) AS c_double_precision,
+  CAST(c_real AS CHAR) AS c_real
+FROM cdm_dt_numeric
+ORDER BY FIELD(case_id, 'NULL', 'ZERO', 'NORMAL', 'MIN', 'MAX');
+
+SELECT
+  'ALIASES' AS section_name,
+  case_id,
+  CAST(serial_value AS CHAR) AS serial_value,
+  CAST(c_bool AS CHAR) AS c_bool,
+  CAST(c_boolean AS CHAR) AS c_boolean
+FROM cdm_dt_alias
+ORDER BY serial_value;
+
+SELECT
+  'TEMPORAL_UTC' AS section_name,
+  case_id,
+  CAST(c_date AS CHAR) AS c_date,
+  CAST(c_time0 AS CHAR) AS c_time0,
+  CAST(c_time6 AS CHAR) AS c_time6,
+  CAST(c_datetime0 AS CHAR) AS c_datetime0,
+  CAST(c_datetime6 AS CHAR) AS c_datetime6,
+  CAST(c_timestamp0 AS CHAR) AS c_timestamp0,
+  CAST(c_timestamp6 AS CHAR) AS c_timestamp6,
+  CAST(c_year AS CHAR) AS c_year
+FROM cdm_dt_temporal
+ORDER BY FIELD(case_id, 'NULL', 'ZERO', 'NORMAL', 'MIN', 'MAX', 'NEGATIVE_TIME');
+
+SELECT
+  'CHARACTER' AS section_name,
+  case_id,
+  c_char,
+  CHAR_LENGTH(c_char) AS c_char_chars,
+  OCTET_LENGTH(c_char) AS c_char_bytes,
+  HEX(c_char) AS c_char_hex,
+  c_varchar,
+  CHAR_LENGTH(c_varchar) AS c_varchar_chars,
+  OCTET_LENGTH(c_varchar) AS c_varchar_bytes,
+  HEX(c_varchar) AS c_varchar_hex,
+  c_tinytext,
+  c_text,
+  c_mediumtext,
+  c_longtext,
+  c_enum,
+  c_set
+FROM cdm_dt_character
+ORDER BY FIELD(case_id, 'NULL', 'EMPTY', 'NORMAL', 'UNICODE', 'BOUNDARY');
+
+SELECT
+  'CHARACTER_LONG' AS section_name,
+  case_id,
+  expected_characters,
+  CHAR_LENGTH(c_longtext) AS actual_characters,
+  expected_bytes,
+  OCTET_LENGTH(c_longtext) AS actual_bytes,
+  SHA2(c_longtext, 256) AS sha256
+FROM cdm_dt_character_long
+ORDER BY expected_characters;
+
+SELECT
+  'BINARY_LOB' AS section_name,
+  case_id,
+  HEX(c_binary) AS c_binary_hex,
+  OCTET_LENGTH(c_binary) AS c_binary_bytes,
+  HEX(c_varbinary) AS c_varbinary_hex,
+  OCTET_LENGTH(c_varbinary) AS c_varbinary_bytes,
+  HEX(c_tinyblob) AS c_tinyblob_hex,
+  OCTET_LENGTH(c_tinyblob) AS c_tinyblob_bytes,
+  CASE
+    WHEN OCTET_LENGTH(c_blob) <= 257 THEN HEX(c_blob)
+    ELSE CONCAT('sha256:', SHA2(c_blob, 256))
+  END AS c_blob_fact,
+  OCTET_LENGTH(c_blob) AS c_blob_bytes,
+  CASE
+    WHEN OCTET_LENGTH(c_mediumblob) <= 257 THEN HEX(c_mediumblob)
+    ELSE CONCAT('sha256:', SHA2(c_mediumblob, 256))
+  END AS c_mediumblob_fact,
+  OCTET_LENGTH(c_mediumblob) AS c_mediumblob_bytes,
+  CASE
+    WHEN OCTET_LENGTH(c_longblob) <= 257 THEN HEX(c_longblob)
+    ELSE CONCAT('sha256:', SHA2(c_longblob, 256))
+  END AS c_longblob_fact,
+  OCTET_LENGTH(c_longblob) AS c_longblob_bytes
+FROM cdm_dt_binary_lob
+ORDER BY FIELD(case_id, 'NULL', 'EMPTY', 'BYTES', 'BOUNDARY_256', 'BOUNDARY_257', 'ONE_MIB');
+
+SELECT
+  'BINARY_LONG' AS section_name,
+  case_id,
+  expected_bytes,
+  OCTET_LENGTH(c_longblob) AS actual_bytes,
+  SHA2(c_longblob, 256) AS sha256
+FROM cdm_dt_binary_long
+ORDER BY expected_bytes;
+
+SELECT
+  'SPATIAL' AS section_name,
+  case_id,
+  ST_AsText(c_geometry) AS c_geometry_wkt,
+  ST_SRID(c_geometry) AS c_geometry_srid,
+  ST_AsText(c_point) AS c_point_wkt,
+  ST_SRID(c_point) AS c_point_srid,
+  ST_AsText(c_linestring) AS c_linestring_wkt,
+  ST_SRID(c_linestring) AS c_linestring_srid,
+  ST_AsText(c_polygon) AS c_polygon_wkt,
+  ST_SRID(c_polygon) AS c_polygon_srid,
+  ST_AsText(c_multipoint) AS c_multipoint_wkt,
+  ST_SRID(c_multipoint) AS c_multipoint_srid,
+  ST_AsText(c_multilinestring) AS c_multilinestring_wkt,
+  ST_SRID(c_multilinestring) AS c_multilinestring_srid,
+  ST_AsText(c_multipolygon) AS c_multipolygon_wkt,
+  ST_SRID(c_multipolygon) AS c_multipolygon_srid,
+  ST_AsText(c_geometrycollection) AS c_geometrycollection_wkt,
+  ST_SRID(c_geometrycollection) AS c_geometrycollection_srid
+FROM cdm_dt_spatial
+ORDER BY FIELD(case_id, 'NULL', 'SRID_0', 'SRID_4326');
+
+DELIMITER $$
+CREATE PROCEDURE cdm_verify_optional_types()
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM cdm_dt_character_long
+    WHERE case_id = 'LIMIT_PLUS_ONE'
+  ) THEN
+    SELECT 'LIMIT_PLUS_ONE_FIXTURE' AS section_name,
+      'PRESENT' AS feature_status,
+      @@max_allowed_packet AS max_allowed_packet;
+  ELSE
+    SELECT 'LIMIT_PLUS_ONE_FIXTURE' AS section_name,
+      'OMITTED_MAX_ALLOWED_PACKET_TOO_SMALL' AS feature_status,
+      @@max_allowed_packet AS max_allowed_packet;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'cdm_data_types'
+      AND table_name = 'cdm_dt_spatial'
+      AND column_name = 'c_geomcollection'
+  ) THEN
+    SET @cdm_sql = 'SELECT
+      ''SPATIAL_GEOMCOLLECTION_ALIAS'' AS section_name,
+      case_id,
+      ST_AsText(c_geomcollection) AS c_geomcollection_wkt,
+      ST_SRID(c_geomcollection) AS c_geomcollection_srid
+    FROM cdm_dt_spatial
+    ORDER BY FIELD(case_id, ''NULL'', ''SRID_0'', ''SRID_4326'')';
+    PREPARE cdm_stmt FROM @cdm_sql;
+    EXECUTE cdm_stmt;
+    DEALLOCATE PREPARE cdm_stmt;
+  ELSE
+    SELECT 'SPATIAL_GEOMCOLLECTION_ALIAS' AS section_name,
+      'NOT_APPLICABLE_BEFORE_8.0' AS feature_status;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'cdm_data_types'
+      AND table_name = 'cdm_dt_json'
+  ) THEN
+    SET @cdm_sql = 'SELECT
+      ''JSON'' AS section_name,
+      case_id,
+      c_json,
+      JSON_TYPE(c_json) AS json_type,
+      JSON_VALID(c_json) AS json_valid,
+      CHAR_LENGTH(CAST(c_json AS CHAR)) AS normalized_characters,
+      SHA2(CAST(c_json AS CHAR), 256) AS normalized_sha256
+    FROM cdm_dt_json
+    ORDER BY FIELD(case_id,
+      ''SQL_NULL'', ''JSON_NULL'', ''SCALAR'', ''OBJECT'',
+      ''ARRAY'', ''DEEP'', ''UNICODE'', ''LONG'')';
+    PREPARE cdm_stmt FROM @cdm_sql;
+    EXECUTE cdm_stmt;
+    DEALLOCATE PREPARE cdm_stmt;
+  ELSE
+    SELECT 'JSON' AS section_name, 'NOT_APPLICABLE_BEFORE_5.7' AS feature_status;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'cdm_data_types'
+      AND table_name = 'cdm_dt_vector'
+  ) THEN
+    SET @cdm_sql = 'SELECT
+      ''VECTOR'' AS section_name,
+      case_id,
+      VECTOR_TO_STRING(c_vector_1) AS c_vector_1,
+      VECTOR_DIM(c_vector_1) AS c_vector_1_dim,
+      VECTOR_TO_STRING(c_vector_3) AS c_vector_3,
+      VECTOR_DIM(c_vector_3) AS c_vector_3_dim,
+      VECTOR_TO_STRING(c_vector_1024) AS c_vector_1024,
+      VECTOR_DIM(c_vector_1024) AS c_vector_1024_dim
+    FROM cdm_dt_vector
+    ORDER BY FIELD(case_id, ''NULL'', ''ONE_DIMENSION'', ''NORMAL'', ''LONG'')';
+    PREPARE cdm_stmt FROM @cdm_sql;
+    EXECUTE cdm_stmt;
+    DEALLOCATE PREPARE cdm_stmt;
+  ELSE
+    SELECT 'VECTOR' AS section_name, 'NOT_APPLICABLE_BEFORE_9.0' AS feature_status;
+  END IF;
+END$$
+DELIMITER ;
+
+CALL cdm_verify_optional_types();
+DROP PROCEDURE cdm_verify_optional_types;
+
+SET SESSION time_zone = @cdm_saved_time_zone;

--- a/tests/frontend/README.md
+++ b/tests/frontend/README.md
@@ -35,6 +35,7 @@ PASS/FAIL，只维护当前真实入口、数据准备、操作、断言和清�
 | 工单    | [`ticket/ticket_detail.md`](ticket/ticket_detail.md)                                       | 工单列表 → `/#/ticket/:id`   | 进度、分析明细、SQL 只读展示、权限与自动刷新 | Smoke、Main Flow、Extreme、Lifecycle、Permission、State Consistency                |
 | CI/CD | [`cicd/release_flow_change_record_refresh.md`](cicd/release_flow_change_record_refresh.md) | CI/CD 列表 → `/#/cicd/:id` | 变更记录轮询、级联进度、关闭工单后的终态回收   | Smoke、Main Flow、Repeat And Concurrency、Lifecycle、Permission、State Consistency |
 | 数据源   | [`datasource/driver_default_selection.md`](datasource/driver_default_selection.md)           | 实例列表 → `/#/datasource/add` | 后端默认驱动契约、家族和版本默认选择        | Smoke、Main Flow、Boundaries、Lifecycle、Permission、State Consistency              |
+| SQL    | [sql/datasource_type_display.md](sql/datasource_type_display.md) | 对象树、/#/sql、浏览表数据 | 全类型元数据、读取器、长内容和三链路一致性 | Smoke、Main Flow、Boundaries、Extreme、Failure、Lifecycle、Permission、State Consistency |
 
 新增用户流程时，在对应业务目录创建一份文档，并同步更新本索引。文档结构以 [`TEMPLATE.md`](TEMPLATE.md) 为准。
 

--- a/tests/frontend/sql/datasource_type_display.md
+++ b/tests/frontend/sql/datasource_type_display.md
@@ -1,0 +1,254 @@
+# 数据源全类型展示
+
+## Purpose
+
+验证同一批数据库类型在 CloudDM 的对象元数据、SQL 工作台结果和只读表数据浏览三条链路中采用一致、可读且无精度损失的展示，并防止未知类型、长内容、二进制和空间值导致结果集错误或会话异常。
+
+## Scope
+
+- 页面与路由：SQL 工作台 /#/sql、数据源对象树、表结构和“浏览表数据”入口。
+- 关联接口与状态：对象元数据加载、SQL 执行 WebSocket、结果分页、单元格详情与完整复制。
+- 关联源码：
+  - backend/clouddm-utils/cg-schema/src/main/java/com/clougence/adapter/mysql/MySQLTypes.java
+  - backend/clouddm-plugins/clouddm-ds/dsc-common-mysql/src/main/java/com/clougence/clouddm/dsfamily/mysql/execute/MyColReader.java
+  - backend/clouddm-platform/cgdm-sidecar/src/main/java/com/clougence/clouddm/worker/component/session/storage/RowStorage.java
+  - backend/clouddm-platform/cgdm-components/cg-com-results-file/src/main/java/com/clougence/clouddm/component/resultfile/ResultFileReader.java
+  - frontend/src/views/sql/components/Result.vue
+- 数据资产：tests/dbs/data-types/mysql/。
+- 首轮不覆盖：导出文件、生成 INSERT SQL、数据修改、保存、删除、排序和筛选。
+
+## Preconditions
+
+- 目标为本地或明确授权的非生产测试环境。
+- DmAloneLauncher 已通过 IDEA 启动并完成健康检查。
+- Chrome 已登录具有数据源查看、SQL 查询和只读表浏览权限的测试账号。
+- 已将 tests/dbs/data-types/mysql/setup.sql 执行到待测 MySQL 数据源。
+- 已执行 verify.sql，并确认长度、HEX、WKT、SRID 和精确数值与 fixture 一致。
+- CloudDM 中的数据源连接默认 schema 可选择 cdm_data_types。
+- Chrome 中本任务使用或打开的全部标签页位于 codex 标签页组。
+
+## Test Data
+
+| 编号 | 数据说明 | 构造方式 | 稳定标识 | 清理方式 |
+|---|---|---|---|---|
+| DTD01 | 数值、位和别名 | setup.sql 创建 cdm_dt_numeric、cdm_dt_alias | case_id | cleanup.sql |
+| DTD02 | 日期时间 | setup.sql 创建 cdm_dt_temporal，事实查询固定为 UTC | case_id | cleanup.sql |
+| DTD03 | 字符、Unicode 和特殊字符 | setup.sql 创建 cdm_dt_character | case_id | cleanup.sql |
+| DTD04 | 255/256/257 与 4 MiB 边界文本 | setup.sql 创建 cdm_dt_character_long | case_id | cleanup.sql |
+| DTD05 | 二进制和 BLOB | setup.sql 创建 cdm_dt_binary_lob、cdm_dt_binary_long | case_id | cleanup.sql |
+| DTD06 | JSON | MySQL 5.7+ 条件创建 cdm_dt_json | case_id | cleanup.sql |
+| DTD07 | 全部可实例化空间类型 | setup.sql 创建 cdm_dt_spatial | case_id | cleanup.sql |
+| DTD08 | VECTOR | MySQL 9.0+ 条件创建 cdm_dt_vector；仓库必测目标为 9.7 | case_id | cleanup.sql |
+
+默认预览字符数 256、在线单列上限 4 MiB 来自 DmDsUtils.fetchResultLimit 和 fillRequestConfig。超出 4 MiB 一档用于验证受控限制，不要求读取超过配置上限的完整内容。
+
+## Suites
+
+### DTD-SMOKE-01 对象树和表结构加载
+
+- 风险/目的：P0，确认合法类型不会使 schema、表或字段元数据整体加载失败。
+- 初始路由与状态：进入 /#/sql，目标 MySQL 数据源在线，尚未展开 cdm_data_types。
+- 测试数据：DTD01 至 DTD08 中当前版本适用的表。
+- 准备方法：执行 setup.sql 后在对象树刷新目标数据源。
+- Chrome 操作：
+  1. 通过可见对象树展开目标数据源和 cdm_data_types。
+  2. 逐个展开所有 cdm_dt_ 前缀表并进入表结构。
+  3. 对照 manifest.yaml 和 verify.sql 的 METADATA 结果检查字段。
+  4. 检查相关元数据 HTTP 请求、Console 和后端日志。
+- 预期结果：
+  1. schema 和每张适用表均可展开，没有整树加载失败或缺表。
+  2. 字段名、数据库归一化类型、长度、精度、标度、UNSIGNED、字符集和排序规则与数据库事实一致。
+  3. JSON 在 5.6 不出现，VECTOR 在 9.0 前不出现；这是适用性差异而非失败。
+  4. 请求业务结果成功，没有相关 4xx/5xx、Console 错误或后端转换异常。
+- 恢复/清理：保持 fixture，供后续场景复用。
+
+### DTD-MAIN-01 精确数值、时间与字符查询
+
+- 风险/目的：P0，防止大整数、定点数、零日期、负 TIME、Unicode 和空值被截断、舍入或混淆。
+- 初始路由与状态：在 /#/sql 打开目标数据源查询页签，schema 为 cdm_data_types。
+- 测试数据：DTD01、DTD02、DTD03。
+- 准备方法：确认 verify.sql 的 NUMERIC、ALIASES、TEMPORAL_UTC 和 CHARACTER 结果已通过数据库侧校验。
+- Chrome 操作：
+  1. 依次执行 SELECT * FROM cdm_dt_numeric ORDER BY FIELD(case_id,'NULL','ZERO','NORMAL','MIN','MAX')。
+  2. 执行 SELECT * FROM cdm_dt_alias ORDER BY serial_value。
+  3. 先执行 SET time_zone = '+00:00'，再查询 cdm_dt_temporal。
+  4. 查询 cdm_dt_character，并查看 NORMAL、UNICODE 和 BOUNDARY 行。
+  5. 检查每次执行的 WebSocket 正常终态、结果行列数、相关请求、Console 和后端日志。
+- 预期结果：
+  1. BIGINT UNSIGNED 18446744073709551615、负 BIGINT 超过 JavaScript 安全整数的值和 DECIMAL(65,30) 与 verify.sql 文本完全一致。
+  2. FLOAT/DOUBLE 按数据库返回的近似值展示，不使用定点数预期强行比较。
+  3. 日期时间包含 fsp 0/6，负 TIME 和 UTC TIMESTAMP 均与数据库事实一致。
+  4. NULL 显示为专用 NULL 样式，空串显示为空单元格，数字 0 显示为 0，三者不混淆。
+  5. 中文、emoji、组合字符、引号和换行无乱码；CHAR 尾随空格按数据库归一化事实验收。
+  6. 不出现 Unsupported、undefined、[object Object] 或相关异常。
+- 恢复/清理：关闭本场景新增结果页签。
+
+### DTD-MAIN-02 二进制、JSON、空间与向量查询
+
+- 风险/目的：P0/P1，确认非普通字符串类型具有稳定可读表示。
+- 初始路由与状态：同 DTD-MAIN-01。
+- 测试数据：DTD05、DTD06、DTD07、DTD08。
+- 准备方法：从 manifest.yaml 确认当前 MySQL 版本的适用类型。
+- Chrome 操作：
+  1. 查询 cdm_dt_binary_lob 的 NULL、EMPTY、BYTES、BOUNDARY_256 和 BOUNDARY_257 行。
+  2. 若适用，查询 cdm_dt_json 全部行。
+  3. 查询 cdm_dt_spatial 全部行，不在 SELECT 中主动调用 ST_AsText。
+  4. 若适用，直接执行 SELECT * FROM cdm_dt_vector ORDER BY case_id。
+  5. 对关键单元格打开详情并使用复制按钮；与 verify.sql 的 HEX、JSON、WKT、SRID 或 VECTOR_TO_STRING 数值事实比较。
+  6. 检查 WebSocket 终态、请求、Console 和后端日志。
+- 预期结果：
+  1. 二进制以稳定十六进制文本展示；X'' 与 NULL 可区分，00/FF 字节不产生乱码。
+  2. JSON 的 SQL NULL、JSON null、标量、对象、数组、深层对象、Unicode 和长对象可区分且为有效 JSON 文本。
+  3. GEOMETRY、POINT、LINESTRING、POLYGON、MULTIPOINT、MULTILINESTRING、MULTIPOLYGON 和两种集合声明均显示合法 WKT；非零地理 SRS 的坐标轴顺序与默认 ST_AsText 一致，不出现原始二进制、替换字符或 WKB Error。
+  4. VECTOR 显示为与 VECTOR_TO_STRING 数值等价的数组文本；Unsupported 不能作为通过结果。
+  5. 任一列问题不得中断同一结果集的其他列或 SQL 会话。
+- 恢复/清理：关闭本场景新增结果页签。
+
+### DTD-BOUNDARY-01 NULL、空值、零值和别名
+
+- 风险/目的：P1，防止视觉相同但语义不同的数据被混为一类。
+- 初始路由与状态：DTD-MAIN-01 查询结果可重新执行。
+- 测试数据：DTD01、DTD02、DTD03、DTD05。
+- 准备方法：无额外准备。
+- Chrome 操作：
+  1. 在同一结果中逐列比较 NULL、ZERO 或 EMPTY 行。
+  2. 比较 BOOL/BOOLEAN、INT/INTEGER、DEC/NUMERIC/FIXED、DOUBLE PRECISION/REAL 和 SERIAL 的元数据及值。
+  3. 打开空字符串、空字节串和 NULL 的单元格详情。
+- 预期结果：
+  1. NULL 使用专用 NULL 样式；空串、空 SET、空字节串和数值 0 不显示为 NULL。
+  2. 别名按数据库规范化后的元数据展示，值与对应规范类型一致。
+  3. BINARY(8) 的空输入按数据库零字节填充事实展示，不误判为空 VARBINARY。
+- 恢复/清理：关闭详情弹窗。
+
+### DTD-BOUNDARY-02 255、256、257 预览边界
+
+- 风险/目的：P1，确认默认 256 字符预览的边界标记、详情和完整复制正确。
+- 初始路由与状态：同 DTD-MAIN-01。
+- 测试数据：DTD04、DTD05。
+- 准备方法：查询 cdm_dt_character_long 中前三行和 cdm_dt_binary_long 中前三行。
+- Chrome 操作：
+  1. 比较 255、256、257 三行的单元格内容与截断角标。
+  2. 双击 257 单元格打开详情。
+  3. 使用单元格复制按钮复制 257 内容，并在非敏感临时编辑器中仅核对长度、首字符和末字符。
+  4. 对文本和二进制各执行一次。
+- 预期结果：
+  1. 255 和 256 不显示不完整角标；257 显示角标。
+  2. 257 的详情可取得完整内容，复制长度与数据库事实一致。
+  3. 二进制预览和完整内容都保持十六进制契约，字节数与十六进制字符数的换算一致。
+  4. 没有空 chunk、重复 chunk、错行或错列。
+- 恢复/清理：关闭详情弹窗，清空临时编辑器内容。
+
+### DTD-EXTREME-01 1 MiB 与在线单列上限
+
+- 风险/目的：P0/P1，验证流式读取阈值和 4 MiB 配置上限两侧的受控行为。
+- 初始路由与状态：同 DTD-MAIN-01，浏览器和后端日志均已记录测试前基线。
+- 测试数据：DTD04、DTD05 的 ONE_MIB、LIMIT_MINUS_ONE、LIMIT_EXACT、LIMIT_PLUS_ONE。
+- 准备方法：每次只查询一行一列，避免同一结果集累计大小干扰。
+- Chrome 操作：
+  1. 分别查询 1 MiB、4194303 和 4194304 字节的文本与二进制单元格。
+  2. 对每个结果打开详情并获取完整内容，核对长度或 SHA-256，不把完整内容粘贴到聊天或日志。
+  3. 单独查询 4194305 字节一档。
+  4. 检查页面消息、WebSocket 终态、相关请求、Console 和后端日志。
+- 预期结果：
+  1. 1 MiB、4194303 和 4194304 字节在配置允许范围内可完成查询，预览有截断标记且详情可读取完整内容。
+  2. 4194305 字节触发明确、受控的单列上限结果或错误，不使会话断开、不误报成功、不留下永久 loading。
+  3. 后续执行 SELECT 1 AS recovery_probe 成功，证明会话可恢复。
+- 恢复/清理：关闭长内容详情和结果页签。
+
+### DTD-REPEAT-01 重复执行与结果页签切换
+
+- 风险/目的：P1，防止异步结果错位或旧响应覆盖新结果。
+- 初始路由与状态：保留一个数值结果和一个空间结果。
+- 测试数据：DTD01、DTD07。
+- 准备方法：无额外准备。
+- Chrome 操作：
+  1. 连续重新执行同一只读查询两次，等待每次正常终态。
+  2. 在数值和空间结果页签间往返切换。
+  3. 快速切换后打开固定 case_id 的单元格详情。
+- 预期结果：
+  1. 每次只生成一个完整终态结果，不出现永久 loading 或重复行。
+  2. 页签列定义和值不串台；详情 resultId、行和列对应当前可见单元格。
+  3. 无旧响应覆盖新结果或 WebSocket 重连风暴。
+- 恢复/清理：关闭新增结果页签。
+
+### DTD-FAILURE-01 不支持类型和限制后的恢复
+
+- 风险/目的：P0，确保类型读取失败被定位到单元格且不破坏执行通道。
+- 初始路由与状态：存在当前版本适用但 CloudDM 暂未支持的 fixture，或已执行 DTD-EXTREME-01 超限一档。
+- 测试数据：使用未来 manifest 新增但尚未支持的类型；当前基线没有此类类型时，用 LIMIT_PLUS_ONE 验证受控失败。
+- 准备方法：不得伪造生产类型或修改线上数据。
+- Chrome 操作：
+  1. 执行风险查询并等待明确终态。
+  2. 记录可见错误，不记录认证头、请求体或含 token 的完整 WebSocket URL。
+  3. 紧接着执行 SELECT 1 AS recovery_probe。
+- 预期结果：
+  1. 风险查询不导致 SQL 会话、页面或后端进程崩溃。
+  2. 错误可关联具体类型或配置上限，不显示 undefined 或无限 loading。
+  3. recovery_probe 返回 1；相关资源正常释放。
+- 恢复/清理：关闭失败结果与恢复探针结果。
+
+### DTD-LIFECYCLE-01 分页、刷新与重新进入
+
+- 风险/目的：P1，确认同一 fixture 在结果生命周期变化后仍保持一致。
+- 初始路由与状态：已完成 DTD-MAIN-01 和 DTD-MAIN-02。
+- 测试数据：所有当前版本适用 fixture。
+- 准备方法：选择一张有五行以上的表。
+- Chrome 操作：
+  1. 切换结果分页、结果页签和执行信息页签后返回。
+  2. 刷新页面，重新从对象树进入同一表并执行同一查询。
+  3. 从对象树使用“浏览表数据”进入只读浏览，再退出并重新进入。
+- 预期结果：
+  1. 切换和重新执行后的行列、类型和值一致。
+  2. 表数据浏览与 SQL 工作台对同一 case_id 的展示契约一致。
+  3. 刷新后无过期 resultId 请求、额外失败重试或相关 Console 错误。
+- 恢复/清理：关闭测试查询页签和表浏览页签。
+
+### DTD-PERMISSION-01 只读账号边界
+
+- 风险/目的：P0，确认首轮验收不依赖写权限且只读入口不会暴露可执行写操作。
+- 初始路由与状态：Chrome 使用只有 schema 查看和 SELECT 权限的测试账号。
+- 测试数据：现有 fixture。
+- 准备方法：由具备授权的准备账号预先执行 setup.sql；浏览器账号不执行 setup 或 cleanup。
+- Chrome 操作：
+  1. 执行 DTD-SMOKE-01 与一条 SELECT 查询。
+  2. 从对象树进入只读表浏览。
+  3. 观察写入、保存和删除入口的权限状态，但不尝试绕过 UI。
+- 预期结果：
+  1. 元数据、SELECT 和只读浏览可用。
+  2. 无权限写入口隐藏或禁用；页面不要求授予额外写权限。
+  3. 相关请求无意外 403；不存在越权写请求。
+- 恢复/清理：退出只读浏览。
+
+### DTD-STATE-01 三链路与数据库事实一致
+
+- 风险/目的：P0，防止某一页面单独看似正确但与数据库或另一条产品链路不一致。
+- 初始路由与状态：数据库 verify.sql、对象元数据、SQL 结果和表浏览均已取得当前状态。
+- 测试数据：每个适用类型至少一个 NORMAL 或边界 case_id。
+- 准备方法：使用 manifest.yaml 逐项勾选，不按肉眼印象抽样。
+- Chrome 操作：
+  1. 对照 verify.sql 检查对象元数据。
+  2. 对照相同 case_id 检查 SQL 结果与表浏览。
+  3. 检查最终 HTTP、WebSocket、Console 和后端日志。
+- 预期结果：
+  1. 每个适用类型在三条链路都有结论，无未说明缺项。
+  2. 数据库事实、SQL 结果和表浏览语义一致。
+  3. P0/P1 全部关闭后才能给出整体 PASS；任何必测版本 BLOCKED 时不得整体 PASS。
+- 恢复/清理：进入 Cleanup。
+
+## Cleanup
+
+1. 关闭本流程创建的结果页签、查询页签、详情弹窗和表浏览页签。
+2. 由具备授权的准备账号执行 tests/dbs/data-types/mysql/cleanup.sql。
+3. 刷新对象树，确认只移除了 cdm_data_types。
+4. 恢复 Chrome 原视口、缩放、网络条件和测试账号。
+5. 确认没有遗留执行中 SQL、轮询或 WebSocket 重连。
+
+## Skip Conditions
+
+- Chrome 未登录、账号无查询权限或目标数据源未配置时，浏览器验收为 BLOCKED；不得用 curl 或其他浏览器替代。
+- MySQL 5.6 跳过 JSON，MySQL 9.0 前跳过 VECTOR；manifest 已定义的版本差异不计为失败。
+- max_allowed_packet 不大于 4194305 时跳过 LIMIT_PLUS_ONE；verify.sql 必须明确报告该环境约束，且 4 MiB 整数边界仍需执行。
+- 只有仓库明确停止支持的版本才可标为不支持；没有环境时标为 BLOCKED，不得标为 PASS 或无说明 SKIP。
+- 无只读账号时 DTD-PERMISSION-01 可标记 SKIP，但管理员账号结果不能替代权限覆盖。
+- 无法安全获取超过 1 MiB 内容的摘要时可跳过粘贴或导出，只保留详情长度与数据库摘要核对；不得把敏感或超长内容写入报告。
+- Repeat And Concurrency 只覆盖只读重复执行和页签切换；写入双击与多用户并发不在首轮范围。


### PR DESCRIPTION
## Summary

- Decode MySQL BIT, TIME, spatial, and VECTOR values correctly, including Connector/J 8 compatibility with MySQL 9 VECTOR results.
- Restore full-mode table browsing by injecting the datasource configuration service and combining split ResultSetMeta and ResultSet messages.
- Keep binary result paging metadata in hexadecimal-character units and load all remaining chunks before copying cell details.
- Add reusable, version-aware MySQL data-type fixtures and frontend acceptance coverage.

## Related Issues

None

## Test Plan (Required)

- [ ] Not tested (explain why below)
- [x] Unit tests
- [x] Integration tests
- [x] Frontend lint / build
- [x] Backend build
- [x] Manual verification

Details:

```text
PASS - cd backend && ./gradlew :dsc-common-mysql:build :cg-com-results-file:build :cgdm-console:build :cgdm-sidecar:build --parallel --max-workers=8
PASS - cd frontend && npm run lint
PASS - cd frontend && npm run check-i18n
PASS - cd package && ./all_build.sh web
PASS - Runtime data-type verification against MySQL 5.6.51, 5.7.44, 8.0.46, 8.4.11, and 9.7.1.
PASS - Verified BIT unsigned boundaries, signed/fractional TIME durations, SRID 0/4326 spatial values, and VECTOR NULL/1D/3D/1024D cases.
PASS - Verified full-mode table browsing and complete hexadecimal BLOB detail paging/copy.
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [x] Documentation was updated when behavior or usage changed.
- [x] Tests were added or updated for behavior changes.
- [x] I confirmed that generated files, dependency directories, logs, and local build artifacts are not included.
