### PR TITLE
chore(release): prepare 4.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | Homepage | https://www.cdmgr.com/                          |
 | Documentation | https://www.cdmgr.com/docs/intro/product_intro  |
 | License | Apache License 2.0                              |
-| Current version | 4.1.1                                           |
+| Current version | 4.1.2                                           |
 | Main languages | Java, JavaScript / TypeScript                   |
 | Deployment modes | Standalone (Alone), Cluster (Console + Sidecar) |
 | Deployment targets | Install package, Docker, Kubernetes             |
@@ -93,7 +93,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.1
+  bladepipe/cgdm-alone:4.1.2
 
 # Faster image pulls in China
 docker run -d --name cgdm-alone \
@@ -102,7 +102,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.2
 ```
 
 Host directory mount example:
@@ -116,7 +116,7 @@ docker run -d --name cgdm-alone \
   -v /data/cgdm/logs:/root/cgdm/alone/logs \
   -v /data/cgdm/data:/root/cgdm/alone/data \
   -v /data/cgdm/mysql:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.1
+  bladepipe/cgdm-alone:4.1.2
 ```
 
 When `/data/cgdm/conf` is empty, CloudDM initializes it with the default configuration files on startup.
@@ -140,25 +140,25 @@ Before upgrading, back up Docker volumes or database data. To upgrade, remove th
 ```bash
 # Default image
 docker rm -f cgdm-alone
-docker pull bladepipe/cgdm-alone:4.1.1
+docker pull bladepipe/cgdm-alone:4.1.2
 docker run -d --name cgdm-alone \
   -p 8222:8222 \
   -v cgdm_alone_conf:/root/cgdm/alone/conf \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.1
+  bladepipe/cgdm-alone:4.1.2
 
 # China acceleration image
 docker rm -f cgdm-alone
-docker pull cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
+docker pull cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.2
 docker run -d --name cgdm-alone \
   -p 8222:8222 \
   -v cgdm_alone_conf:/root/cgdm/alone/conf \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.2
 ```
 
 ### Initialization

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,7 +1,7 @@
 #
 org.gradle.jvmargs=-Xmx8192m -Djava.net.preferIPv4Stack=true
 #
-cg.clouddm.main.version=4.1.1
+cg.clouddm.main.version=4.1.2
 #
 cg.lib.jackson.version=2.19.0
 cg.lib.slf4j.version=2.0.17

--- a/docs/README.cn.md
+++ b/docs/README.cn.md
@@ -32,7 +32,7 @@
 | 官网   | https://www.cdmgr.com/                         |
 | 文档   | https://www.cdmgr.com/docs/intro/product_intro |
 | 开源协议 | Apache License 2.0                             |
-| 当前版本 | 4.1.1                                          |
+| 当前版本 | 4.1.2                                          |
 | 主要语言 | Java、JavaScript / TypeScript                   |
 | 部署模式 | 单机模式（Alone）、集群模式（Console + Sidecar）            |
 | 部署方式 | 安装包、Docker、Kubernetes                          |
@@ -97,7 +97,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.1
+  bladepipe/cgdm-alone:4.1.2
 
 # 中国地区，使用加速镜像
 docker run -d --name cgdm-alone \
@@ -106,7 +106,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.2
 ```
 
 本地目录挂载示例：
@@ -120,7 +120,7 @@ docker run -d --name cgdm-alone \
   -v /data/cgdm/logs:/root/cgdm/alone/logs \
   -v /data/cgdm/data:/root/cgdm/alone/data \
   -v /data/cgdm/mysql:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.1
+  bladepipe/cgdm-alone:4.1.2
 ```
 
 当 `/data/cgdm/conf` 是空目录时，CloudDM 会在启动时自动写入默认配置文件。
@@ -145,25 +145,25 @@ gunzip -c cgdm-alone-image-<arch>.tar.gz | docker load
 ```bash
 # 默认镜像
 docker rm -f cgdm-alone
-docker pull bladepipe/cgdm-alone:4.1.1
+docker pull bladepipe/cgdm-alone:4.1.2
 docker run -d --name cgdm-alone \
   -p 8222:8222 \
   -v cgdm_alone_conf:/root/cgdm/alone/conf \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.1
+  bladepipe/cgdm-alone:4.1.2
 
 # 中国区加速镜像
 docker rm -f cgdm-alone
-docker pull cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
+docker pull cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.2
 docker run -d --name cgdm-alone \
   -p 8222:8222 \
   -v cgdm_alone_conf:/root/cgdm/alone/conf \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.2
 ```
 
 ### 初始化

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -31,7 +31,7 @@
 | Homepage           | https://www.cdmgr.com/                          |
 | Documentation      | https://www.cdmgr.com/docs/intro/product_intro  |
 | License            | Apache License 2.0                              |
-| Current version    | 4.1.1                                           |
+| Current version    | 4.1.2                                           |
 | Main languages     | Java, JavaScript / TypeScript                   |
 | Deployment modes   | Standalone (Alone), Cluster (Console + Sidecar) |
 | Deployment targets | Install package, Docker, Kubernetes             |
@@ -99,7 +99,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.1
+  bladepipe/cgdm-alone:4.1.2
 
 # Faster image pulls in China
 docker run -d --name cgdm-alone \
@@ -108,7 +108,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.2
 ```
 
 Host directory mount example:
@@ -122,7 +122,7 @@ docker run -d --name cgdm-alone \
   -v /data/cgdm/logs:/root/cgdm/alone/logs \
   -v /data/cgdm/data:/root/cgdm/alone/data \
   -v /data/cgdm/mysql:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.1
+  bladepipe/cgdm-alone:4.1.2
 ```
 
 When `/data/cgdm/conf` is empty, CloudDM initializes it with the default configuration files on startup.
@@ -150,25 +150,25 @@ with the same volumes.
 ```bash
 # Default image
 docker rm -f cgdm-alone
-docker pull bladepipe/cgdm-alone:4.1.1
+docker pull bladepipe/cgdm-alone:4.1.2
 docker run -d --name cgdm-alone \
   -p 8222:8222 \
   -v cgdm_alone_conf:/root/cgdm/alone/conf \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.1
+  bladepipe/cgdm-alone:4.1.2
 
 # China acceleration image
 docker rm -f cgdm-alone
-docker pull cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
+docker pull cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.2
 docker run -d --name cgdm-alone \
   -p 8222:8222 \
   -v cgdm_alone_conf:/root/cgdm/alone/conf \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.2
 ```
 
 ### Initialization

--- a/docs/guides/deployment.cn.md
+++ b/docs/guides/deployment.cn.md
@@ -97,11 +97,11 @@ http://localhost:8222
 
 ```bash
 # 一键启动
-docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.1
+docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.2
 
 # 中国镜像加速
 docker run -d --name cgdm-alone -p 8222:8222 \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.2
 ```
 
 持久化数据卷：
@@ -114,7 +114,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.1
+  bladepipe/cgdm-alone:4.1.2
 
 # 挂载到宿主机目录
 mkdir -p /data/cgdm/{conf,logs,data,mysql}
@@ -125,7 +125,7 @@ docker run -d --name cgdm-alone \
   -v /data/cgdm/logs:/root/cgdm/alone/logs \
   -v /data/cgdm/data:/root/cgdm/alone/data \
   -v /data/cgdm/mysql:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.1
+  bladepipe/cgdm-alone:4.1.2
 ```
 
 当 `/data/cgdm/conf` 是空目录时，容器启动时会自动写入默认配置文件。
@@ -137,7 +137,7 @@ docker run -d --name cgdm-alone \
 ```yml
 services:
   dm_alone:
-    image: clougence/cgdm-alone:4.1.1
+    image: clougence/cgdm-alone:4.1.2
     container_name: cgdm-alone
     restart: always
     ports:
@@ -277,7 +277,7 @@ docker run -d --name dm_console \
   -e DB_DATABASE=cdmgr \
   -e DB_USERNAME=root \
   -e DB_PASSWORD=123456 \
-  bladepipe/cgdm-console:4.1.1
+  bladepipe/cgdm-console:4.1.2
 
 # 启动 Sidecar
 docker run -d --name dm_sidecar \
@@ -288,13 +288,13 @@ docker run -d --name dm_sidecar \
   -e DM_CLIENT_WSN=<请替换为实际值> \
   -e APP_SERVE_NAME=dm_console \
   -e APP_SERVE_PORT=8008 \
-  bladepipe/cgdm-sidecar:4.1.1
+  bladepipe/cgdm-sidecar:4.1.2
 ```
 
 中国区部署时，只需将镜像替换为：
 
-- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-console:4.1.1`
-- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-sidecar:4.1.1`
+- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-console:4.1.2`
+- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-sidecar:4.1.2`
 
 ### 4.3 使用 Docker Compose
 
@@ -316,7 +316,7 @@ services:
     command: [ "mysqld", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]
 
   dm_console:
-    image: clougence/cgdm-console:x86_64-4.1.1
+    image: clougence/cgdm-console:x86_64-4.1.2
     container_name: cgdm-console
     restart: always
     ports:
@@ -341,7 +341,7 @@ services:
       DB_PASSWORD: 123456
 
   dm_sidecar:
-    image: clougence/cgdm-sidecar:x86_64-4.1.1
+    image: clougence/cgdm-sidecar:x86_64-4.1.2
     container_name: cgdm-sidecar
     restart: always
     depends_on:

--- a/docs/guides/deployment.en.md
+++ b/docs/guides/deployment.en.md
@@ -97,11 +97,11 @@ The system automatically enters the initialization wizard. After completing data
 
 ```bash
 # One-click startup
-docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.1
+docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.2
 
 # China registry acceleration
 docker run -d --name cgdm-alone -p 8222:8222 \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.2
 ```
 
 Persistent data volumes:
@@ -114,7 +114,7 @@ docker run -d --name cgdm-alone \
   -v cgdm_alone_logs:/root/cgdm/alone/logs \
   -v cgdm_alone_data:/root/cgdm/alone/data \
   -v cgdm_mysql_data:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.1
+  bladepipe/cgdm-alone:4.1.2
 
 # Mount to host directories
 mkdir -p /data/cgdm/{conf,logs,data,mysql}
@@ -125,7 +125,7 @@ docker run -d --name cgdm-alone \
   -v /data/cgdm/logs:/root/cgdm/alone/logs \
   -v /data/cgdm/data:/root/cgdm/alone/data \
   -v /data/cgdm/mysql:/var/lib/mysql \
-  bladepipe/cgdm-alone:4.1.1
+  bladepipe/cgdm-alone:4.1.2
 ```
 
 When `/data/cgdm/conf` is empty, the container initializes it with the default configuration files on startup.
@@ -137,7 +137,7 @@ After the build is complete, deployment files named `docker-alone-xxx.yml` will 
 ```yml
 services:
   dm_alone:
-    image: clougence/cgdm-alone:4.1.1
+    image: clougence/cgdm-alone:4.1.2
     container_name: cgdm-alone
     restart: always
     ports:
@@ -277,7 +277,7 @@ docker run -d --name dm_console \
   -e DB_DATABASE=cdmgr \
   -e DB_USERNAME=root \
   -e DB_PASSWORD=123456 \
-  bladepipe/cgdm-console:4.1.1
+  bladepipe/cgdm-console:4.1.2
 
 # Start Sidecar
 docker run -d --name dm_sidecar \
@@ -288,13 +288,13 @@ docker run -d --name dm_sidecar \
   -e DM_CLIENT_WSN=<replace_with_actual_value> \
   -e APP_SERVE_NAME=dm_console \
   -e APP_SERVE_PORT=8008 \
-  bladepipe/cgdm-sidecar:4.1.1
+  bladepipe/cgdm-sidecar:4.1.2
 ```
 
 For China deployment, simply replace the images with:
 
-- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-console:4.1.1`
-- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-sidecar:4.1.1`
+- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-console:4.1.2`
+- `cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-sidecar:4.1.2`
 
 ### 4.3 Use Docker Compose
 
@@ -316,7 +316,7 @@ services:
     command: [ "mysqld", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]
 
   dm_console:
-    image: clougence/cgdm-console:x86_64-4.1.1
+    image: clougence/cgdm-console:x86_64-4.1.2
     container_name: cgdm-console
     restart: always
     ports:
@@ -341,7 +341,7 @@ services:
       DB_PASSWORD: 123456
 
   dm_sidecar:
-    image: clougence/cgdm-sidecar:x86_64-4.1.1
+    image: clougence/cgdm-sidecar:x86_64-4.1.2
     container_name: cgdm-sidecar
     restart: always
     depends_on:

--- a/docs/reference/faq.cn.md
+++ b/docs/reference/faq.cn.md
@@ -15,7 +15,7 @@ CloudDM 是一款免费且开源的团队化数据库管理平台，提供数据
 使用单机模式 Docker 镜像，并访问 `http://localhost:8222`：
 
 ```bash
-docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.1
+docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.2
 ```
 
 ### 评估或试用时应该选择哪种部署模式？

--- a/docs/reference/faq.en.md
+++ b/docs/reference/faq.en.md
@@ -15,7 +15,7 @@ Yes. CloudDM is released under the Apache License 2.0. See [LICENSE.txt](../../L
 Use the standalone Docker image and open `http://localhost:8222`:
 
 ```bash
-docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.1
+docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.2
 ```
 
 ### Which deployment mode should I use for evaluation?

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -4,6 +4,7 @@ Release notes are grouped by version. Each version directory contains one file p
 
 | Version | Chinese | English |
 |---------|---------|---------|
+| v4.1.2 | [中文](v4.1.2/index.cn.md) | [English](v4.1.2/index.en.md) |
 | v4.1.1 | [中文](v4.1.1/index.cn.md) | [English](v4.1.1/index.en.md) |
 | v4.1.0 | [中文](v4.1.0/index.cn.md) | [English](v4.1.0/index.en.md) |
 | v4.0.1 | [中文](v4.0.1/index.cn.md) | [English](v4.0.1/index.en.md) |

--- a/docs/release-notes/v4.1.2/index.cn.md
+++ b/docs/release-notes/v4.1.2/index.cn.md
@@ -1,0 +1,30 @@
+## 亮点
+
+- SQL 工单新增跨数据库 DML 数据影响与执行计划分析，可持续展示准备、分析、跳过和失败状态，并支持中断恢复。
+- SQL 引擎按数据库版本和会话参数统一解析、拆分、行为分析、安全规则、列血缘与改写能力。
+- 工单列表支持按描述和内联 SQL 内容搜索，结果集下载支持自定义文件名，并记录导出与下载审计。
+- Oracle 支持可配置客户端字符集，ClickHouse 补充复杂数据类型读取及连接兼容性。
+
+## 新增
+
+- 新增 SQL 工单 DML 数据影响与执行计划分析，覆盖 MySQL、TiDB、Doris、达梦、PostgreSQL、SAP HANA、SQL Server、Oracle、StarRocks、DB2、MariaDB 和 ClickHouse；支持版本适配、影响行数估算、阶段进度、跳过原因、错误明细、租约恢复和并发隔离（[#260](https://github.com/ClouGence/open-cdm/issues/260)）。
+- 数据库驱动支持在后端 `drivers.xml` 中声明默认版本，前端创建数据源时优先选择该默认版本（[#260](https://github.com/ClouGence/open-cdm/issues/260)）。
+- 结果集文件下载前可自定义文件名，并校验空名称和非法字符（[#299](https://github.com/ClouGence/open-cdm/issues/299)）。
+- 操作审计新增结果集导出和下载事件，记录文件与操作信息，并优化审计资源字段展示（[#302](https://github.com/ClouGence/open-cdm/issues/302)）。
+- 工单列表支持按描述和内联 SQL 内容模糊搜索，同时展示可复制的工单描述（[#305](https://github.com/ClouGence/open-cdm/issues/305)）。
+- Oracle 数据源新增客户端字符集配置，支持常用字符集或自定义值，并按配置解码 `CHAR` 和 `VARCHAR2` 数据（[#295](https://github.com/ClouGence/open-cdm/issues/295)）。
+
+## 优化
+
+- 优化 SQL 引擎架构，使用会话实际数据库版本和 `sql_mode` 等参数驱动解析、补全、拆分、行为与权限分析、列血缘和 SQL 改写；增强 MySQL 多版本语法、达梦安全域、Doris 与 StarRocks 建表元数据解析等能力（[#260](https://github.com/ClouGence/open-cdm/issues/260)）。
+- 优化工单分析与执行详情，集中展示数据影响统计、对象和行为、分析错误、执行阶段与进度，并提升大 SQL 预览和任务恢复的稳定性（[#260](https://github.com/ClouGence/open-cdm/issues/260)）。
+- 完善数据源配置、安全规则详情、SQL 日志和环境页面的国际化与布局；工单执行状态、操作按钮和调度日志会按用户语言展示（[#300](https://github.com/ClouGence/open-cdm/issues/300)、[#304](https://github.com/ClouGence/open-cdm/issues/304)）。
+
+## 修复
+
+- 修复 Docker 单机模式重建容器时未从持久化配置恢复内置 MySQL 账号的问题；现在会按目标数据库创建缺失账号或同步密码，由社区贡献者 [@sunjiajie](https://github.com/sunjiajie) 提交，感谢贡献（[#272](https://github.com/ClouGence/open-cdm/issues/272)）。
+- 修复 ClickHouse `fetchSize` 兼容问题，并支持 JSON、Map、Tuple、Dynamic、Variant 和嵌套 Array 等类型读取，由社区贡献者 [@BetaCat0](https://github.com/BetaCat0) 提交，感谢贡献（[#253](https://github.com/ClouGence/open-cdm/issues/253)）。
+- 修复 SQL 函数参数中包含非 `SELECT` 域时，列血缘和安全规则分析可能发生类型转换错误的问题，由社区贡献者 [@sunjiajie](https://github.com/sunjiajie) 提交，感谢贡献（[#259](https://github.com/ClouGence/open-cdm/issues/259)）。
+- 修复同步 OpenAPI 查询未返回非 Console 展示模式的错误和警告，以及同一消息可能被重复收集的问题，由社区贡献者 [@sunjiajie](https://github.com/sunjiajie) 提交，感谢贡献（[#281](https://github.com/ClouGence/open-cdm/issues/281)）。
+- 修复重复包装执行计划语句、`EXPLAIN` 行为分类不准确，以及 ClickHouse 旧版本连接、DB2 for z/OS 时区参数和 SQL Server `SHOWPLAN` 执行兼容性问题（[#260](https://github.com/ClouGence/open-cdm/issues/260)）。
+- 修复 ClickHouse `EXISTS` 子查询、Oracle 多行 `INSERT ... VALUES` 和 PostgreSQL `INSERT ... SELECT` 等语法分析问题，并改进多数据库 `INSERT` 影响行数估算（[#260](https://github.com/ClouGence/open-cdm/issues/260)）。

--- a/docs/release-notes/v4.1.2/index.en.md
+++ b/docs/release-notes/v4.1.2/index.en.md
@@ -1,0 +1,30 @@
+## Highlights
+
+- SQL approval tickets now provide cross-database DML impact and execution-plan analysis with live preparation, analysis, skip, and failure states plus interruption recovery.
+- SQL engines now share version- and session-aware parsing, splitting, behavior analysis, security rules, column lineage, and rewriting.
+- Tickets can be searched by description or inline SQL, result downloads can be renamed, and result exports and downloads are audited.
+- Oracle adds configurable client character sets, while ClickHouse gains complex-type reads and connection compatibility improvements.
+
+## Added
+
+- Added DML impact and execution-plan analysis for SQL approval tickets across MySQL, TiDB, Doris, Dameng, PostgreSQL, SAP HANA, SQL Server, Oracle, StarRocks, DB2, MariaDB, and ClickHouse, including version-aware plans, affected-row estimates, phase progress, skip reasons, error details, lease-based recovery, and concurrent isolation ([#260](https://github.com/ClouGence/open-cdm/issues/260)).
+- Database drivers can now declare a default version in the backend `drivers.xml`, which is preferred when creating a datasource in the frontend ([#260](https://github.com/ClouGence/open-cdm/issues/260)).
+- Result-set downloads can now be renamed before downloading, with validation for empty names and invalid characters ([#299](https://github.com/ClouGence/open-cdm/issues/299)).
+- Added operation-audit events for result-set exports and downloads, including file and operation details, and improved audit resource display ([#302](https://github.com/ClouGence/open-cdm/issues/302)).
+- Ticket lists can now search descriptions and inline SQL content, and display copyable ticket descriptions ([#305](https://github.com/ClouGence/open-cdm/issues/305)).
+- Added an Oracle client-character-set option with common and custom values, applying the configured encoding when reading `CHAR` and `VARCHAR2` data ([#295](https://github.com/ClouGence/open-cdm/issues/295)).
+
+## Improved
+
+- Improved the SQL engine architecture by using the live database version and session parameters such as `sql_mode` for parsing, completion, splitting, behavior and permission analysis, column lineage, and SQL rewriting; also expanded multi-version MySQL syntax, Dameng security domains, and Doris and StarRocks table metadata parsing ([#260](https://github.com/ClouGence/open-cdm/issues/260)).
+- Improved ticket analysis and execution details with consolidated impact statistics, objects and behaviors, analysis errors, execution phases, and progress, together with more reliable large-SQL previews and task recovery ([#260](https://github.com/ClouGence/open-cdm/issues/260)).
+- Improved localization and layout for datasource configuration, security-rule details, SQL logs, and environment pages; ticket execution states, actions, and scheduling logs now follow the user's language ([#300](https://github.com/ClouGence/open-cdm/issues/300), [#304](https://github.com/ClouGence/open-cdm/issues/304)).
+
+## Fixed
+
+- Fixed Docker standalone containers failing to restore the embedded MySQL application account from persisted configuration after recreation; missing accounts are now created and password drift is reconciled for the target database, contributed by community contributor [@sunjiajie](https://github.com/sunjiajie)—thank you! ([#272](https://github.com/ClouGence/open-cdm/issues/272)).
+- Fixed ClickHouse `fetchSize` compatibility and added support for reading JSON, Map, Tuple, Dynamic, Variant, and nested Array values, contributed by community contributor [@BetaCat0](https://github.com/BetaCat0)—thank you! ([#253](https://github.com/ClouGence/open-cdm/issues/253)).
+- Fixed column-lineage and security-rule analysis potentially failing with a type-cast error when SQL function arguments contain non-`SELECT` domains, contributed by community contributor [@sunjiajie](https://github.com/sunjiajie)—thank you! ([#259](https://github.com/ClouGence/open-cdm/issues/259)).
+- Fixed synchronous OpenAPI queries omitting errors and warnings from non-Console display modes and potentially collecting the same message more than once, contributed by community contributor [@sunjiajie](https://github.com/sunjiajie)—thank you! ([#281](https://github.com/ClouGence/open-cdm/issues/281)).
+- Fixed duplicate execution-plan wrapping, incorrect `EXPLAIN` behavior classification, and compatibility issues affecting older ClickHouse connections, DB2 for z/OS timezone parameters, and SQL Server `SHOWPLAN` execution ([#260](https://github.com/ClouGence/open-cdm/issues/260)).
+- Fixed SQL analysis for ClickHouse `EXISTS` subqueries, Oracle multi-row `INSERT ... VALUES`, and PostgreSQL `INSERT ... SELECT`, and improved `INSERT` affected-row estimates across databases ([#260](https://github.com/ClouGence/open-cdm/issues/260)).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14,7 +14,7 @@ CloudDM is a free and open-source database management platform for teams, provid
 | Homepage | https://www.cdmgr.com/ |
 | Documentation | https://www.cdmgr.com/docs/intro/product_intro |
 | License | Apache License 2.0 |
-| Current version | 4.1.1 |
+| Current version | 4.1.2 |
 | Main languages | Java, JavaScript / TypeScript |
 | Deployment modes | Standalone (Alone), Cluster (Console + Sidecar) |
 | Deployment targets | Install package, Docker, Kubernetes |
@@ -67,14 +67,14 @@ CloudDM can be deployed with install packages, Docker, Docker Compose, or Kubern
 Run CloudDM in standalone mode with Docker:
 
 ```bash
-docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.1
+docker run -d --name cgdm-alone -p 8222:8222 bladepipe/cgdm-alone:4.1.2
 ```
 
 For faster image pulls in China:
 
 ```bash
 docker run -d --name cgdm-alone -p 8222:8222 \
-  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.1
+  cloudcanal-registry.cn-shanghai.cr.aliyuncs.com/clougence/cgdm-alone:4.1.2
 ```
 
 After startup, open:

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,25 @@
+# Codex Skills
+
+This directory contains project-specific Codex skills for maintaining open-cdm.
+
+## Available Skills
+
+| Skill | Purpose |
+| --- | --- |
+| [`open-cdm-change-version`](open-cdm-change-version/SKILL.md) | Prepare an open-cdm release from an exact Git range, generate bilingual release notes, attribute community contributors, and update current version references. |
+
+## Usage
+
+Invoke a skill with an explicit target version:
+
+```text
+$open-cdm-change-version 4.1.2
+```
+
+The skill keeps commit, tag, branch, and push operations outside the release-preparation workflow unless the user explicitly requests them.
+
+## Structure
+
+Each skill keeps its entry instructions in `SKILL.md`. Optional `agents/`, `references/`, and `scripts/` directories provide UI metadata, focused guidance, and deterministic helpers used by that skill.
+
+When updating a skill, keep links relative to its directory, avoid generated output and credentials, and validate any changed helper scripts before submitting the change.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,6 @@
-# Codex Skills
+# Skills
 
-This directory contains project-specific Codex skills for maintaining open-cdm.
+This directory contains project-specific skills for maintaining open-cdm.
 
 ## Available Skills
 

--- a/skills/open-cdm-change-version/SKILL.md
+++ b/skills/open-cdm-change-version/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: open-cdm-change-version
+description: Prepare an open-cdm release for a user-specified version by deriving changes from Git tags, generating bilingual release notes with community-contributor attribution, and updating current version references. Use for open-cdm version bumps or release preparation; do not use for unrelated projects or rewriting earlier release history.
+---
+
+# Open CDM Change Version
+
+Prepare an open-cdm version from an exact Git range. The target version must come from the user's request; never infer it only from the current branch name.
+
+## Establish the Release Range
+
+1. Locate the intended repository, read its applicable instructions, and inspect the working tree before editing.
+2. Refresh tags from the configured remote when current remote state is required. Do not switch branches merely to inspect a tag or release branch.
+3. Prefer the exact target tag `v<target-version>` as the end ref. If the tag does not exist because release notes are being prepared before tagging, require an explicit end ref such as the current release branch or `HEAD`; do not silently substitute it.
+4. Use the newest stable SemVer tag reachable from the end ref and lower than the target version as the default start tag. Stable release notes intentionally ignore intermediate `-rc` tags so the range remains cumulative. Override the start tag only when the user or release topology requires it.
+5. Confirm the start tag is an ancestor of the end ref and that the end ref belongs to the checkout being edited.
+
+Resolve the bundled scripts relative to this `SKILL.md`; do not assume a fixed installation or repository path.
+
+## Collect Changes and Contributors
+
+Run the read-only collector before changing version files:
+
+```bash
+python3 <resolved-skill-directory>/scripts/collect_release_changes.py \
+  --repo <open-cdm-repository-root> \
+  --version <target-version> \
+  --github
+```
+
+The collector defaults to `v<target-version>` and chooses the previous stable tag. Use `--to-ref` for an explicitly approved pre-tag ref and `--from-tag` when the default previous tag is not the intended release boundary.
+
+`--github` resolves each PR's login and `authorAssociation` through the authenticated GitHub CLI. Treat `OWNER`, `MEMBER`, and `COLLABORATOR` as project members. Treat `CONTRIBUTOR`, `FIRST_TIMER`, `FIRST_TIME_CONTRIBUTOR`, and `NONE` as community contributors, excluding bot accounts. If PR attribution cannot be resolved, do not guess from a display name or email; resolve it before finalizing the notes.
+
+Commit messages and PR titles are source material, not release-note prose. Inspect commit bodies or diffs when a message is vague, and do not invent user-visible behavior. Re-run the collector with `--include-files` only when changed paths would help resolve an unclear commit.
+
+## Generate Release Notes
+
+Before drafting, read [references/release-notes.md](references/release-notes.md). Create or update only the target version's files:
+
+- `docs/release-notes/v<target-version>/index.cn.md`
+- `docs/release-notes/v<target-version>/index.en.md`
+
+Map every material commit in the range to a note or record why it is intentionally omitted. Every included community contribution must mention and link the contributor in the same bullet. Do not silently omit a community-authored PR merely because it is documentation, maintenance, or difficult to classify.
+
+Keep the Chinese and English files semantically aligned. Never modify earlier version directories as part of a new release.
+
+## Update Version References
+
+After both release-note files exist, dry-run the version updater, review its file list and counts, then apply it:
+
+```bash
+python3 <resolved-skill-directory>/scripts/change_open_cdm_version.py \
+  --repo <open-cdm-repository-root> \
+  --version <target-version> \
+  --dry-run
+```
+
+Run the same command without `--dry-run` only when the scope is correct. The updater changes the Gradle main version, current-version tables, supported Docker image tags, and the release-note index. It inserts the index row only when both target release-note files exist.
+
+Do not broaden a routine release to dependency properties, CI tuning, generated output, or historical release-note content. Do not commit, tag, switch branches, or push unless the user explicitly asks.
+
+## Validate
+
+- Review the full diff and ensure unrelated pre-existing changes remain untouched.
+- Re-run the collector and account for every commit and every community contributor in the chosen range.
+- Verify Chinese and English notes cover the same changes, PR links resolve to the correct repository, and each community `@username` links to that GitHub profile.
+- Confirm the release-note index points to two existing files.
+- Search current public documentation for stale version tables and supported image tags; ignore intentional historical versions.
+- Report the start tag, end ref, commit count, community contributors, changed files, and validation performed.

--- a/skills/open-cdm-change-version/agents/openai.yaml
+++ b/skills/open-cdm-change-version/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Open CDM Prepare Release"
+  short_description: "Prepare version references and release notes"
+  default_prompt: "Use $open-cdm-change-version to prepare open-cdm version TARGET_VERSION from its release tag, including bilingual release notes."

--- a/skills/open-cdm-change-version/references/release-notes.md
+++ b/skills/open-cdm-change-version/references/release-notes.md
@@ -1,0 +1,58 @@
+# Open CDM Release Note Guide
+
+Use the latest complete release-note pair in `docs/release-notes/` as the repository's live style reference. The `v4.1.0` pair is the baseline when a later complete pair is unavailable.
+
+## Structure
+
+Create two files with matching content and ordering:
+
+| Chinese | English |
+| --- | --- |
+| `## 亮点` | `## Highlights` |
+| `## 新增` | `## Added` |
+| `## 优化` | `## Improved` |
+| `## 修复` | `## Fixed` |
+
+Use two to four concise highlights for the most important release themes. Highlights summarize outcomes and normally omit PR links. Omit an empty detail section rather than inventing content, but keep both languages structurally aligned.
+
+## Turn Commits into Notes
+
+- Describe user-visible capability, behavior, reliability, compatibility, or operator impact. Do not copy raw Conventional Commit prefixes into the note.
+- Classify `feat` as Added when it introduces a capability and as Improved when it extends an existing one. Classify `fix` as Fixed. Use the actual behavior rather than the prefix when they disagree.
+- Consolidate closely related commits into one coherent bullet, retaining all relevant PR links and community acknowledgements.
+- Exclude release bumps, formatting-only changes, tests, and internal chores unless they materially affect users or contributors.
+- Inspect the commit body or diff when the subject is too vague. If the behavior still cannot be established, surface the uncertainty instead of guessing.
+- Account for every commit in the selected range. Keep a temporary coverage mapping while drafting when the range is non-trivial.
+
+Use the repository slug detected from `origin` when building links. Match the existing release-note convention for PR or issue references:
+
+```markdown
+[#123](https://github.com/OWNER/REPOSITORY/issues/123)
+```
+
+## Community Attribution
+
+Use PR metadata rather than Git author names or email addresses. A non-bot PR author with `authorAssociation` equal to `CONTRIBUTOR`, `FIRST_TIMER`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` is a community contributor. `OWNER`, `MEMBER`, and `COLLABORATOR` are project members.
+
+Every release-note bullet containing a community contribution must include the linked GitHub login before its PR links.
+
+Chinese pattern:
+
+```markdown
+- 新增或修复的内容，由社区贡献者 [@octocat](https://github.com/octocat) 提交，感谢贡献（[#123](https://github.com/OWNER/REPOSITORY/issues/123)）。
+```
+
+English pattern:
+
+```markdown
+- Added or fixed behavior, contributed by community contributor [@octocat](https://github.com/octocat)—thank you! ([#123](https://github.com/OWNER/REPOSITORY/issues/123)).
+```
+
+When consolidating work from multiple community contributors, mention every contributor exactly once in that bullet. Do not silently drop a community-authored change; include it in an appropriate section or explicitly ask how it should be represented.
+
+## Bilingual Quality
+
+- Preserve the same facts, scope, PR references, contributor mentions, and order in both languages.
+- Write natural Chinese and English rather than translating word for word.
+- Keep product terms and identifiers consistent with existing documentation, including SQL, CI/CD, Sidecar, datasource names, and code identifiers in backticks.
+- Avoid marketing claims that are not supported by the release range.

--- a/skills/open-cdm-change-version/scripts/change_open_cdm_version.py
+++ b/skills/open-cdm-change-version/scripts/change_open_cdm_version.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Update the Open CDM build version and public version references."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+VERSION_RE = re.compile(r"^v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z._-]*)?)$")
+
+TARGET_FILES = [
+    "backend/gradle.properties",
+    "README.md",
+    "docs/README.cn.md",
+    "docs/README.en.md",
+    "docs/guides/deployment.cn.md",
+    "docs/guides/deployment.en.md",
+    "docs/reference/faq.cn.md",
+    "docs/reference/faq.en.md",
+    "docs/release-notes/README.md",
+    "llms-full.txt",
+]
+
+MAIN_VERSION_PROPERTY_RE = re.compile(
+    r"(?P<prefix>^[ \t]*cg\.clouddm\.main\.version[ \t]*=[ \t]*)"
+    r"(?P<version>[^\s#]+)"
+    r"(?P<suffix>[ \t]*(?:#.*)?$)",
+    flags=re.MULTILINE,
+)
+
+IMAGE_PREFIX_RE = re.compile(
+    r"(?P<prefix>"
+    r"(?:bladepipe|clougence)/cgdm-(?:alone|console|sidecar):"
+    r"|cloudcanal-registry\.cn-shanghai\.cr\.aliyuncs\.com/clougence/cgdm-(?:alone|console|sidecar):"
+    r")"
+    r"(?P<arch>(?:x86_64|aarch64|arm64|amd64)-)?"
+    r"(?P<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z._-]*)?)"
+)
+
+CURRENT_VERSION_ROW_RE = re.compile(
+    r"(?P<prefix>\|\s*(?:Current version|当前版本)\s*\|\s*)"
+    r"(?P<version>[^|\n]+?)"
+    r"(?P<suffix>\s*\|)"
+)
+
+
+def normalize_version(raw: str) -> str:
+    match = VERSION_RE.match(raw.strip())
+    if not match:
+        raise ValueError(
+            f"invalid version {raw!r}; expected explicit SemVer like 1.2.3"
+        )
+    return match.group(1)
+
+
+def detect_repo(explicit_repo: str | None) -> Path:
+    if explicit_repo:
+        repo = Path(explicit_repo).expanduser().resolve()
+    else:
+        cwd = Path.cwd().resolve()
+        candidates = [cwd, *cwd.parents]
+        repo = next(
+            (
+                path
+                for path in candidates
+                if (path / "backend/gradle.properties").is_file()
+                and (path / "docs").is_dir()
+                and (path / "README.md").is_file()
+            ),
+            cwd,
+        )
+
+    if (
+        not (repo / "backend/gradle.properties").is_file()
+        or not (repo / "README.md").is_file()
+        or not (repo / "docs").is_dir()
+    ):
+        raise FileNotFoundError(f"{repo} does not look like the open-cdm repository root")
+    return repo
+
+
+def update_release_notes_index(text: str, version: str) -> tuple[str, int]:
+    row = f"| v{version} | [中文](v{version}/index.cn.md) | [English](v{version}/index.en.md) |"
+    if re.search(rf"^\|\s*v{re.escape(version)}\s*\|", text, flags=re.MULTILINE):
+        return text, 0
+
+    lines = text.splitlines(keepends=True)
+    for idx, line in enumerate(lines):
+        if re.match(r"^\|\s*-+\s*\|\s*-+\s*\|\s*-+\s*\|", line):
+            newline = "\n" if line.endswith("\n") else ""
+            lines.insert(idx + 1, row + newline)
+            return "".join(lines), 1
+
+    if text and not text.endswith("\n"):
+        text += "\n"
+    return text + row + "\n", 1
+
+
+def update_text(
+    relative_path: str,
+    text: str,
+    version: str,
+    release_notes_ready: bool,
+) -> tuple[str, int]:
+    change_count = 0
+
+    if relative_path == "backend/gradle.properties":
+        def replace_main_version(match: re.Match[str]) -> str:
+            nonlocal change_count
+            if match.group("version") == version:
+                return match.group(0)
+            change_count += 1
+            return f"{match.group('prefix')}{version}{match.group('suffix')}"
+
+        return MAIN_VERSION_PROPERTY_RE.sub(replace_main_version, text), change_count
+
+    def replace_version_row(match: re.Match[str]) -> str:
+        nonlocal change_count
+        old = match.group("version").strip()
+        if old == version:
+            return match.group(0)
+        change_count += 1
+        return f"{match.group('prefix')}{version}{match.group('suffix')}"
+
+    text = CURRENT_VERSION_ROW_RE.sub(replace_version_row, text)
+
+    def replace_image_tag(match: re.Match[str]) -> str:
+        nonlocal change_count
+        old = match.group("version")
+        if old == version:
+            return match.group(0)
+        change_count += 1
+        return f"{match.group('prefix')}{match.group('arch') or ''}{version}"
+
+    text = IMAGE_PREFIX_RE.sub(replace_image_tag, text)
+
+    if relative_path == "docs/release-notes/README.md" and release_notes_ready:
+        text, inserted = update_release_notes_index(text, version)
+        change_count += inserted
+
+    return text, change_count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="Target version, for example 1.2.3")
+    parser.add_argument("--repo", help="Path to the open-cdm repository root")
+    parser.add_argument("--dry-run", action="store_true", help="Print changes without writing files")
+    args = parser.parse_args()
+
+    try:
+        version = normalize_version(args.version)
+        repo = detect_repo(args.repo)
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    total_changes = 0
+    changed_files: list[tuple[str, int]] = []
+    missing_files: list[str] = []
+    release_notes_dir = repo / "docs/release-notes" / f"v{version}"
+    release_notes_ready = all(
+        (release_notes_dir / filename).is_file()
+        for filename in ("index.cn.md", "index.en.md")
+    )
+
+    for relative_path in TARGET_FILES:
+        path = repo / relative_path
+        if not path.exists():
+            missing_files.append(relative_path)
+            continue
+        original = path.read_text(encoding="utf-8")
+        updated, count = update_text(
+            relative_path,
+            original,
+            version,
+            release_notes_ready,
+        )
+        if count:
+            total_changes += count
+            changed_files.append((relative_path, count))
+            if not args.dry_run:
+                path.write_text(updated, encoding="utf-8")
+
+    mode = "dry-run" if args.dry_run else "updated"
+    print(f"{mode}: repo={repo} version={version} changes={total_changes}")
+    for relative_path, count in changed_files:
+        print(f"  {relative_path}: {count}")
+    if missing_files:
+        print("missing:")
+        for relative_path in missing_files:
+            print(f"  {relative_path}")
+    if not release_notes_ready:
+        print(f"release notes index skipped: expected {release_notes_dir}/index.cn.md and index.en.md")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/open-cdm-change-version/scripts/collect_release_changes.py
+++ b/skills/open-cdm-change-version/scripts/collect_release_changes.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Collect Git and GitHub metadata for an Open CDM release range."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from change_open_cdm_version import detect_repo, normalize_version
+
+
+STABLE_TAG_RE = re.compile(r"^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
+BASE_VERSION_RE = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)")
+PR_NUMBER_RES = [
+    re.compile(r"\(#(?P<number>\d+)\)\s*$"),
+    re.compile(r"^Merge pull request #(?P<number>\d+)\b"),
+]
+INTERNAL_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+COMMUNITY_ASSOCIATIONS = {
+    "CONTRIBUTOR",
+    "FIRST_TIMER",
+    "FIRST_TIME_CONTRIBUTOR",
+    "NONE",
+}
+
+
+def run(repo: Path, command: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        cwd=repo,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if check and result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"command failed ({' '.join(command)}): {detail}")
+    return result
+
+
+def git(repo: Path, *args: str) -> str:
+    return run(repo, ["git", *args]).stdout.strip()
+
+
+def ref_exists(repo: Path, ref: str) -> bool:
+    result = run(
+        repo,
+        ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def version_key(version: str) -> tuple[int, int, int]:
+    match = BASE_VERSION_RE.match(version)
+    if not match:
+        raise ValueError(f"cannot derive a stable version key from {version!r}")
+    return tuple(int(match.group(name)) for name in ("major", "minor", "patch"))
+
+
+def resolve_target_ref(repo: Path, version: str, explicit_ref: str | None) -> str:
+    if explicit_ref:
+        if not ref_exists(repo, explicit_ref):
+            raise ValueError(f"target ref {explicit_ref!r} does not exist")
+        return explicit_ref
+
+    target_tag = f"v{version}"
+    if not ref_exists(repo, target_tag):
+        raise ValueError(
+            f"target tag {target_tag!r} does not exist; pass --to-ref for an approved pre-tag ref"
+        )
+    return target_tag
+
+
+def resolve_start_tag(
+    repo: Path,
+    version: str,
+    target_ref: str,
+    explicit_tag: str | None,
+) -> str:
+    if explicit_tag:
+        start_tag = explicit_tag if explicit_tag.startswith("v") else f"v{explicit_tag}"
+        if not ref_exists(repo, start_tag):
+            raise ValueError(f"start tag {start_tag!r} does not exist")
+        return start_tag
+
+    target_key = version_key(version)
+    candidates: list[tuple[tuple[int, int, int], str]] = []
+    for tag in git(repo, "tag", "--merged", target_ref, "--list", "v*").splitlines():
+        match = STABLE_TAG_RE.match(tag)
+        if not match:
+            continue
+        key = tuple(int(match.group(name)) for name in ("major", "minor", "patch"))
+        if key < target_key:
+            candidates.append((key, tag))
+
+    if not candidates:
+        raise ValueError(f"no previous stable tag is reachable from {target_ref!r}")
+    return max(candidates)[1]
+
+
+def ensure_ancestor(repo: Path, start_tag: str, target_ref: str) -> None:
+    result = run(
+        repo,
+        ["git", "merge-base", "--is-ancestor", start_tag, target_ref],
+        check=False,
+    )
+    if result.returncode:
+        raise ValueError(f"start tag {start_tag!r} is not an ancestor of {target_ref!r}")
+
+
+def detect_github_repository(repo: Path) -> str | None:
+    remote_url = git(repo, "remote", "get-url", "origin")
+    match = re.search(r"github\.com[/:](?P<slug>[^/\s]+/[^/\s]+?)(?:\.git)?$", remote_url)
+    if not match:
+        return None
+    return match.group("slug")
+
+
+def extract_pr_number(subject: str) -> int | None:
+    for pattern in PR_NUMBER_RES:
+        match = pattern.search(subject)
+        if match:
+            return int(match.group("number"))
+    return None
+
+
+def resolve_pr(repo: Path, repository: str, number: int) -> tuple[dict[str, object] | None, str | None]:
+    result = run(
+        repo,
+        ["gh", "api", f"repos/{repository}/pulls/{number}"],
+        check=False,
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip()
+        return None, detail
+
+    payload = json.loads(result.stdout)
+    login = payload["user"]["login"]
+    association = payload.get("author_association")
+    is_bot = login.endswith("[bot]")
+    community: bool | None = None
+    if is_bot or association in INTERNAL_ASSOCIATIONS:
+        community = False
+    elif association in COMMUNITY_ASSOCIATIONS:
+        community = True
+
+    return {
+        "number": number,
+        "title": payload["title"],
+        "url": payload["html_url"],
+        "author_login": login,
+        "author_url": payload["user"]["html_url"],
+        "author_association": association,
+        "community_contributor": community,
+    }, None
+
+
+def collect_commit(repo: Path, commit: str, include_files: bool) -> dict[str, object]:
+    raw = git(repo, "show", "-s", "--format=%an%x00%ae%x00%aI%x00%s%x00%b", commit)
+    author_name, author_email, authored_at, subject, body = raw.split("\x00", 4)
+    result: dict[str, object] = {
+        "sha": commit,
+        "short_sha": commit[:10],
+        "authored_at": authored_at,
+        "author_name": author_name,
+        "author_email": author_email,
+        "subject": subject,
+        "body": body.strip(),
+        "pr_number": extract_pr_number(subject),
+        "pr": None,
+    }
+    if include_files:
+        parents = git(repo, "rev-list", "--parents", "-n", "1", commit).split()
+        files: list[str] = []
+        if len(parents) > 1:
+            files = git(repo, "diff", "--name-only", parents[1], commit).splitlines()
+        result["files"] = files
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="Target version, for example 1.2.3")
+    parser.add_argument("--repo", help="Path to the open-cdm repository root")
+    parser.add_argument("--from-tag", help="Override the previous stable release tag")
+    parser.add_argument("--to-ref", help="Override the target tag with an explicit Git ref")
+    parser.add_argument(
+        "--github",
+        action="store_true",
+        help="Resolve PR authors and community status with the authenticated GitHub CLI",
+    )
+    parser.add_argument(
+        "--include-files",
+        action="store_true",
+        help="Include each commit's changed paths for investigating vague messages",
+    )
+    args = parser.parse_args()
+
+    try:
+        version = normalize_version(args.version)
+        repo = detect_repo(args.repo)
+        target_ref = resolve_target_ref(repo, version, args.to_ref)
+        start_tag = resolve_start_tag(repo, version, target_ref, args.from_tag)
+        ensure_ancestor(repo, start_tag, target_ref)
+        repository = detect_github_repository(repo)
+        if args.github and not shutil.which("gh"):
+            raise RuntimeError("--github requires the GitHub CLI")
+        if args.github and not repository:
+            raise RuntimeError("cannot derive a GitHub repository from the origin remote")
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    commit_ids = git(repo, "rev-list", "--reverse", "--first-parent", f"{start_tag}..{target_ref}").splitlines()
+    commits = [collect_commit(repo, commit, args.include_files) for commit in commit_ids]
+    warnings: list[str] = []
+
+    if args.github and repository:
+        for commit in commits:
+            number = commit["pr_number"]
+            if number is None:
+                warnings.append(f"{commit['short_sha']}: no PR number found in commit subject")
+                continue
+            pr, error = resolve_pr(repo, repository, number)
+            commit["pr"] = pr
+            if error:
+                warnings.append(f"PR #{number}: {error}")
+
+    community_contributors = sorted(
+        {
+            commit["pr"]["author_login"]
+            for commit in commits
+            if commit["pr"] and commit["pr"]["community_contributor"] is True
+        },
+        key=str.casefold,
+    )
+    unresolved_attribution = [
+        commit["short_sha"]
+        for commit in commits
+        if commit["pr_number"] is None
+        or (args.github and commit["pr"] is None)
+        or (
+            commit["pr"]
+            and commit["pr"]["community_contributor"] is None
+        )
+    ]
+    current_branch_result = run(
+        repo,
+        ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+        check=False,
+    )
+    target_in_current_head = run(
+        repo,
+        ["git", "merge-base", "--is-ancestor", target_ref, "HEAD"],
+        check=False,
+    ).returncode == 0
+
+    output = {
+        "repository_root": str(repo),
+        "github_repository": repository,
+        "current_branch": current_branch_result.stdout.strip() or None,
+        "current_head": git(repo, "rev-parse", "HEAD"),
+        "target_version": version,
+        "start_tag": start_tag,
+        "start_commit": git(repo, "rev-parse", f"{start_tag}^{{commit}}"),
+        "target_ref": target_ref,
+        "target_commit": git(repo, "rev-parse", f"{target_ref}^{{commit}}"),
+        "target_reachable_from_current_head": target_in_current_head,
+        "commit_count": len(commits),
+        "github_metadata_requested": args.github,
+        "attribution_complete": args.github and not unresolved_attribution,
+        "community_contributors": community_contributors,
+        "unresolved_attribution": unresolved_attribution,
+        "warnings": warnings,
+        "commits": commits,
+    }
+    json.dump(output, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    if args.github and unresolved_attribution:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add semantically aligned Chinese and English release notes for 4.1.2, derived from the exact `v4.1.1..v4.1.2` range.
- Attribute community contributions from `BetaCat0` and `sunjiajie` using GitHub PR metadata.
- Update the Gradle main version, current-version tables, supported Docker image tags, and release-note index to 4.1.2.

## Related Issues

None. This is release preparation for the changes already included in `v4.1.2`.

## Test Plan (Required)

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [ ] Backend build
- [x] Manual verification

Details:

```text
- Re-ran the release collector for v4.1.1..v4.1.2: 14 commits, complete GitHub attribution, no warnings.
- Verified the Chinese and English notes have matching sections, PR references, and contributor attribution.
- Verified all 11 referenced PRs resolve to ClouGence/open-cdm.
- Verified the release-note index targets two existing files.
- Searched current public documentation for stale 4.1.0/4.1.1 current-version tables and supported image tags; none remain.
- Re-ran the version updater in dry-run mode; it reports changes=0.
- Ran git diff --check successfully.
- Build and automated tests were not run because this change only updates release documentation and version references.
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [x] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes. Not applicable: no product behavior changed.
- [x] I confirmed that generated files, dependency directories, logs, and local build artifacts are not included.