### PR TITLE
Error reported when switching redis driver version

### DIFF
--- a/backend/clouddm-plugins/clouddm-ds/ds-redis/src/main/java/com/clougence/clouddm/ds/redis/execute/RedisHooks.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-redis/src/main/java/com/clougence/clouddm/ds/redis/execute/RedisHooks.java
@@ -18,7 +18,9 @@ package com.clougence.clouddm.ds.redis.execute;
 import java.sql.*;
 
 import com.clougence.clouddm.base.metadata.ds.ColMetaData;
-import com.clougence.clouddm.ds.redis.execute.jdbc.JedisConnection;
+import com.clougence.drivers.adapter.AdapterConnManager;
+import com.clougence.drivers.adapter.AdapterConnection;
+import com.clougence.utils.ExceptionUtils;
 import com.clougence.clouddm.sdk.execute.meta.DsMetaService;
 import com.clougence.clouddm.sdk.execute.session.QueryRequest;
 import com.clougence.clouddm.sdk.execute.session.Session;
@@ -126,12 +128,27 @@ public class RedisHooks implements SessionHook {
 
     @Override
     public String getQueryID(Connection conn) throws SQLException {
-        return conn.unwrap(JedisConnection.class).getObjectId();
+        AdapterConnection adapterConn = conn.unwrap(AdapterConnection.class);
+        if (adapterConn == null) {
+            throw new SQLException("failed to unwrap AdapterConnection from " + conn.getClass().getName());
+        }
+        return adapterConn.getObjectId();
     }
 
     @Override
     public void killProcess(Connection conn, String connID) throws SQLException {
-        conn.unwrap(JedisConnection.class).killDriverConnection(connID);
+        AdapterConnection target = AdapterConnManager.getConnection(connID);
+        if (target != null) {
+            try {
+                target.close();
+            } catch (Throwable e) {
+                Throwable root = ExceptionUtils.getRootCause(e);
+                if (root instanceof SQLException) {
+                    throw (SQLException) root;
+                }
+                throw new SQLException(e);
+            }
+        }
     }
 
     @Override

--- a/backend/clouddm-plugins/clouddm-ds/ds-redis/src/main/java/com/clougence/clouddm/ds/redis/execute/RedisMetaService.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-redis/src/main/java/com/clougence/clouddm/ds/redis/execute/RedisMetaService.java
@@ -22,7 +22,7 @@ import java.sql.SQLException;
 import java.util.UUID;
 
 import com.clougence.clouddm.ds.redis.definition.ui.editor.keys.RedisEditorProvider;
-import com.clougence.clouddm.ds.redis.execute.jdbc.JedisConnection;
+import com.clougence.drivers.adapter.AdapterConnection;
 import com.clougence.clouddm.sdk.execute.session.Session;
 import com.clougence.clouddm.sdk.execute.session.rdb.DefaultRdbMetaService;
 import com.clougence.clouddm.sdk.execute.session.rdb.DmRdbUmiService;
@@ -55,7 +55,13 @@ public class RedisMetaService extends DefaultRdbMetaService {
     @Override
     public String getCurrentSchema() {
         try {
-            return this.rdbSession.executeQuery(con -> con.unwrap(JedisConnection.class).getSchema());
+            return this.rdbSession.executeQuery(con -> {
+                AdapterConnection adapterConn = con.unwrap(AdapterConnection.class);
+                if (adapterConn == null) {
+                    throw new SQLException("failed to unwrap AdapterConnection from " + con.getClass().getName());
+                }
+                return adapterConn.getSchema();
+            });
         } catch (Exception e) {
             String msg = "getCurrentSchema failed, " + ExceptionUtils.getRootCauseMessage(e);
             log.error(msg, e);

--- a/backend/clouddm-plugins/clouddm-ds/ds-redis/src/main/java/com/clougence/clouddm/ds/redis/execute/jdbc/JedisConnection.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-redis/src/main/java/com/clougence/clouddm/ds/redis/execute/jdbc/JedisConnection.java
@@ -81,6 +81,8 @@ public class JedisConnection extends AdapterConnection {
             return (T) this;
         } else if (iface == JedisCmd.class) {
             return (T) this.jedisCmd;
+        } else if (AdapterConnection.class.isAssignableFrom(iface) && iface.isInstance(this)) {
+            return (T) this;
         } else {
             return super.unwrap(iface);
         }


### PR DESCRIPTION
AdapterManager.factoryMap is a static global Map. When each driver version is registered, it overwrites the factory corresponding to the same adapter name ("Jedis"). When a user switches back from 6.2.0 to 7.4.1:
The cached 7.4.1 binding reuses the original classloader (CL-7), and RedisHooks refers to the JedisConnection.class of CL-7
However, the JedisConnectionFactory for CL-6 is registered in AdapterManager, and a JedisConnection instance for CL-6 is created
When comparing Class objects using the == operator, if the classes are loaded by different classloaders, the result will be false. As a result, unwrapping will return null, leading to a NullPointerException (NPE)