### PR TITLE
fix(doris): avoid limit rewrite cast for DML

### DIFF
--- a/backend/clouddm-plugins/clouddm-sql/sql-doris/src/main/java/com/clougence/sql/doris/editor/rewrite/DrRewriteSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-doris/src/main/java/com/clougence/sql/doris/editor/rewrite/DrRewriteSpi.java
@@ -108,7 +108,9 @@ public class DrRewriteSpi implements RewriteSpi {
     }
 
     private boolean rewriterLimit(TokenStreamRewriter rewriter, ParseTree astTree, long maxLimit) {
-        DorisParser.StatementDefaultContext dmlStat = (DorisParser.StatementDefaultContext) ((DorisParser.StatementBaseAliasContext) astTree).statementBase();
+        if (!(astTree instanceof DorisParser.StatementBaseAliasContext statement) || !(statement.statementBase() instanceof DorisParser.StatementDefaultContext dmlStat)) {
+            return false;
+        }
         if (dmlStat.query() != null) {
             DorisParser.QueryTermContext queryTerm = dmlStat.query().queryTerm();
             if (queryTerm instanceof DorisParser.QueryTermDefaultContext) {


### PR DESCRIPTION
## Summary

- Guard Doris limit rewriting against non-query statement contexts.
- Leave INSERT and other DML statements unchanged while preserving SELECT limit rewriting.
- Prevent the query preparation path from throwing ClassCastException for INSERT INTO ... WITH ... SELECT statements.

## Related Issues

None.

## Test Plan (Required)

- [ ] Not tested (explain why below)
- [ ] Unit tests
- [ ] Integration tests
- [ ] Frontend lint / build
- [x] Backend build
- [x] Manual verification

Details:

```text
cd backend && ./gradlew :sql-doris:build
BUILD SUCCESSFUL

Ran DrRewriteSpi.rewriteLimit against the reported INSERT INTO ... WITH ... SELECT SQL:
- The statement remains unchanged and no ClassCastException is thrown.
- A regular SELECT statement still receives the configured LIMIT.

Open Code Review checked the modified Java file and reported no findings.
```

## Checklist

- [x] The PR title clearly describes the change.
- [x] The change follows the repository coding standards.
- [x] Documentation was updated when behavior or usage changed.
- [ ] Tests were added or updated for behavior changes.
- [x] I confirmed that generated files, dependency directories, logs, and local build artifacts are not included.
