### PR TITLE
feat(mongodb): support read-only rs/sh shell helpers

### DIFF
--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoDistributeCall.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/execute/jdbc/MongoDistributeCall.java
@@ -24,6 +24,7 @@ import com.clougence.sql.mongodb.parser.ast.commands.AbstractMongoFunc;
 import com.clougence.sql.mongodb.parser.ast.commands.collection.CollectionFunc;
 import com.clougence.sql.mongodb.parser.ast.commands.collection.DataSizeFunc;
 import com.clougence.sql.mongodb.parser.ast.commands.collection.RenameCollectionFunc;
+import com.clougence.sql.mongodb.parser.ast.commands.db.MongoReadCommandFunc;
 import com.clougence.utils.future.CgFuture;
 import com.mongodb.client.MongoClient;
 
@@ -80,6 +81,8 @@ class MongoDistributeCall {
             case GET_PARAMETER:
             case KILL_OP:
                 return ClientCallForCommand.runCommand(sync, client, func.toBson(), request, receive, "admin");
+            case ADMIN_READ:
+                return ClientCallForCommand.runCommand(sync, client, func.toBson(), request, receive, ((MongoReadCommandFunc) func).getDatabase());
             default:
                 throw new UnsupportedOperationException();
         }

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/language/MongoCompletionStrategyCenter.java
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/java/com/clougence/clouddm/ds/mongodb/language/MongoCompletionStrategyCenter.java
@@ -20,6 +20,7 @@ import com.clougence.clouddm.sdk.service.execute.MetaCol;
 import com.clougence.clouddm.sdk.service.execute.MetaObj;
 import com.clougence.clouddm.sdk.service.execute.MetaService;
 import com.clougence.schema.umi.struts.UmiTypes;
+import com.clougence.sql.mongodb.parser.ast.commands.db.MongoAdminReadCommands;
 import com.clougence.utils.StringUtils;
 
 public class MongoCompletionStrategyCenter extends CompletionStrategyCenter {
@@ -31,8 +32,48 @@ public class MongoCompletionStrategyCenter extends CompletionStrategyCenter {
 
     @Override
     protected void register(List<CompletionStrategy> strategies) {
+        // Higher than field strategy so rs./sh. are not treated as collection qualifiers.
+        strategies.add(new MongoShellHelperCompletionStrategy());
         strategies.add(new MongoCollectionCompletionStrategy());
         strategies.add(new MongoFieldCompletionStrategy());
+    }
+
+    private static class MongoShellHelperCompletionStrategy implements CompletionStrategy {
+        @Override
+        public int weight() {
+            return 300;
+        }
+
+        @Override
+        public boolean match(CompletionContext context) {
+            if (context.getPreviousSignificantChar() != '.') {
+                return false;
+            }
+            String qualifier = context.getQualifier();
+            return "rs".equalsIgnoreCase(qualifier) || "sh".equalsIgnoreCase(qualifier);
+        }
+
+        @Override
+        public List<CompletionItem> complete(CompletionContext context, MetaService metaService) {
+            List<String> methods = "rs".equalsIgnoreCase(context.getQualifier())
+                ? MongoAdminReadCommands.listRsMethods()
+                : MongoAdminReadCommands.listShMethods();
+            List<CompletionItem> items = new ArrayList<>();
+            for (String method : methods) {
+                if (!context.matchPrefix(method)) {
+                    continue;
+                }
+                CompletionItem item = new CompletionItem();
+                item.setLabel(method);
+                item.setKind(CompletionItemKind.FUNCTION);
+                item.setUmiType(UmiTypes.Function);
+                item.setIcon("FUNCTION");
+                item.setInsertText(method + "()");
+                item.setWeight(850);
+                items.add(item);
+            }
+            return items;
+        }
     }
 
     private static class MongoCollectionCompletionStrategy implements CompletionStrategy {

--- a/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/resources/META-INF/clougence/db-keywords/mongodb.keywords
+++ b/backend/clouddm-plugins/clouddm-ds/ds-mongodb/src/main/resources/META-INF/clougence/db-keywords/mongodb.keywords
@@ -72,12 +72,14 @@ renameCollection
 replaceOne
 returnKey
 rotateCertificates
+rs
 runCommand
 serverBuildInfo
 serverCmdLineOpts
 serverStatus
 setLogLevel
 setProfilingLevel
+sh
 show
 showRecordId
 shutdownServer

--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/antlr/MongoLexer.g4
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/antlr/MongoLexer.g4
@@ -26,6 +26,8 @@ COMMENT2: '/*' .*? '*/'         -> channel(COMMENT);
 
 /* key command words */
 DB: 'db';
+RS: 'rs';
+SH: 'sh';
 SHOW: 'show';
 DATABASES: 'databases';
 DBS: 'dbs';

--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/antlr/MongoParser.g4
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/antlr/MongoParser.g4
@@ -30,11 +30,35 @@ functionCommand:
     | collectionFunction
     | environmentFunction
     | showFunction
+    | replicaSetFunction
+    | shardingFunction
     | use
     ;
 
 use:
     USE ID
+    ;
+
+replicaSetFunction:
+    RS DOT replicaSetMethod LS_BRACKET (TRUE | FALSE | obj)? RS_BRACKET
+    ;
+
+replicaSetMethod:
+    ID
+    | keyWordId
+    | PRINT_REPLICATION_INFO
+    | PRINT_SECONDARY_REPLICATION_INFO
+    | GET_REPLICATION_INFO
+    ;
+
+shardingFunction:
+    SH DOT shardingMethod LS_BRACKET (TRUE | FALSE | obj)? RS_BRACKET
+    ;
+
+shardingMethod:
+    ID
+    | keyWordId
+    | PRINT_SHARDING_STATUS
     ;
 
 databaseFunction:
@@ -345,6 +369,8 @@ keyWordId:
     | CURRENT_OP
     | DROP_DATABASE
     | EXPLAIN
+    | RS
+    | SH
     ;
 
 

--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/analysis/behavior/MongoBehaviorAnalysisSpi.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/analysis/behavior/MongoBehaviorAnalysisSpi.java
@@ -94,7 +94,7 @@ public class MongoBehaviorAnalysisSpi implements BehaviorAnalysisSpi {
         return switch (type) {
             case FIND, AGGREGATE, FIND_ONE, COUNT, DISTINCT, COUNT_DOCUMENTS -> SplitQueryType.SELECT;
             case DATA_SIZE, HELLO, EXPLAIN -> SplitQueryType.PERFORMANCE;
-            case LIST_COLLECTIONS, LIST_INDEXES, SHOW_DATABASES, SHOW_COLLECTIONS -> SplitQueryType.METADATA;
+            case LIST_COLLECTIONS, LIST_INDEXES, SHOW_DATABASES, SHOW_COLLECTIONS, RS_STATUS, RS_CONF, RS_REPLICATION_INFO, SH_STATUS, SH_BALANCER_STATUS -> SplitQueryType.METADATA;
             case VALIDATE -> SplitQueryType.ADMIN_TABLE;
             case CREATE_INDEX, CREATE_INDEXES -> SplitQueryType.ADD_INDEX;
             case CREATE_VIEW -> SplitQueryType.CREATE_VIEW;
@@ -120,7 +120,7 @@ public class MongoBehaviorAnalysisSpi implements BehaviorAnalysisSpi {
             case FSYNC_UNLOCK -> BehaviorAction.UNLOCK;
             case PROFILE -> BehaviorAction.CONFIGURE;
             case KILL_OP -> BehaviorAction.TERMINATE;
-            case HOST_INFO, CURRENT_OP, SERVER_STATUS, BUILD_INFO, GET_LOG_COMPONENTS, DB_STATS, LATENCY_STATS -> BehaviorAction.READ;
+            case HOST_INFO, CURRENT_OP, SERVER_STATUS, BUILD_INFO, GET_LOG_COMPONENTS, DB_STATS, LATENCY_STATS, RS_STATUS, RS_CONF, RS_REPLICATION_INFO, SH_STATUS, SH_BALANCER_STATUS -> BehaviorAction.READ;
             default -> null;
         };
         if (commandAction != null) {

--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/analysis/security/MongoAnalysisHelper.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/analysis/security/MongoAnalysisHelper.java
@@ -30,7 +30,12 @@ public class MongoAnalysisHelper {
             case FIND_ONE:
             case COUNT:
             case DISTINCT:
-            case COUNT_DOCUMENTS: {
+            case COUNT_DOCUMENTS:
+            case RS_STATUS:
+            case RS_CONF:
+            case RS_REPLICATION_INFO:
+            case SH_STATUS:
+            case SH_BALANCER_STATUS: {
                 return RuleQueryType.READ;
             }
             case DATA_SIZE:

--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/DefaultMongoParserVisitor.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/DefaultMongoParserVisitor.java
@@ -309,6 +309,38 @@ public class DefaultMongoParserVisitor extends AbstractLocationParseTreeVisitor<
     }
 
     @Override
+    public Object visitReplicaSetFunction(MongoParser.ReplicaSetFunctionContext ctx) {
+        String method = ctx.replicaSetMethod().getText();
+        AbstractMongoFunc command = MongoAdminReadCommands.resolveRs(method);
+        if (command == null) {
+            throw new UnsupportedOperationException("Unsupported MongoDB func rs." + method);
+        }
+        this.instStack.push(command);
+        return null;
+    }
+
+    @Override
+    public Object visitReplicaSetMethod(MongoParser.ReplicaSetMethodContext ctx) {
+        return null;
+    }
+
+    @Override
+    public Object visitShardingFunction(MongoParser.ShardingFunctionContext ctx) {
+        String method = ctx.shardingMethod().getText();
+        AbstractMongoFunc command = MongoAdminReadCommands.resolveSh(method);
+        if (command == null) {
+            throw new UnsupportedOperationException("Unsupported MongoDB func sh." + method);
+        }
+        this.instStack.push(command);
+        return null;
+    }
+
+    @Override
+    public Object visitShardingMethod(MongoParser.ShardingMethodContext ctx) {
+        return null;
+    }
+
+    @Override
     public Object visitGetCollectionNames(MongoParser.GetCollectionNamesContext ctx) {
         ListCollectionsFunc listCollectionsFunc = new ListCollectionsFunc();
         listCollectionsFunc.addOption("authorizedCollections", "true");

--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/MongoSplitVisitor.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/MongoSplitVisitor.java
@@ -34,6 +34,16 @@ public class MongoSplitVisitor extends MongoParserBaseVisitor<SplitQueryType> {
     }
 
     @Override
+    public SplitQueryType visitReplicaSetFunction(MongoParser.ReplicaSetFunctionContext ctx) {
+        return SplitQueryType.METADATA;
+    }
+
+    @Override
+    public SplitQueryType visitShardingFunction(MongoParser.ShardingFunctionContext ctx) {
+        return SplitQueryType.METADATA;
+    }
+
+    @Override
     public SplitQueryType visitDbCreateCollection(MongoParser.DbCreateCollectionContext ctx) {
         return SplitQueryType.CREATE_TABLE;
     }
@@ -293,7 +303,7 @@ public class MongoSplitVisitor extends MongoParserBaseVisitor<SplitQueryType> {
             case "profile" -> SplitQueryType.SYSTEM_SETTING_WRITE;
             case "killOp" -> SplitQueryType.ADMIN;
             case "currentOp", "serverStatus" -> SplitQueryType.PERFORMANCE;
-            case "listCollections", "buildInfo", "hello", "hostInfo" -> SplitQueryType.METADATA;
+            case "listCollections", "buildInfo", "hello", "hostInfo", "replSetGetStatus", "replSetGetConfig", "listShards", "balancerStatus", "isMaster" -> SplitQueryType.METADATA;
             case "dropDatabase" -> SplitQueryType.DROP_SCHEMA;
             case "create" -> hasKey(command, "viewOn") ? SplitQueryType.CREATE_VIEW : SplitQueryType.CREATE_TABLE;
             default -> SplitQueryType.UNKNOWN;

--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/ast/CommandType.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/ast/CommandType.java
@@ -49,6 +49,7 @@ public enum CommandType {
     KILL_OP,
     RUN_COMMAND,
     ADMIN_COMMAND,
+    ADMIN_READ,
     FSYNC,
     FSYNC_UNLOCK,
     CURRENT_OP

--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/ast/MongoFuncType.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/ast/MongoFuncType.java
@@ -69,7 +69,12 @@ public enum MongoFuncType {
     FSYNC_LOCK("fsyncLock", com.clougence.sql.mongodb.parser.ast.CommandType.FSYNC, com.clougence.sql.mongodb.parser.ast.CmdKindType.ADMIN),
     FSYNC_UNLOCK("fsyncUnlock", com.clougence.sql.mongodb.parser.ast.CommandType.FSYNC_UNLOCK, com.clougence.sql.mongodb.parser.ast.CmdKindType.ADMIN),
     CURRENT_OP("currentOp", com.clougence.sql.mongodb.parser.ast.CommandType.CURRENT_OP, com.clougence.sql.mongodb.parser.ast.CmdKindType.ADMIN),
-    EXPLAIN("explain", com.clougence.sql.mongodb.parser.ast.CommandType.EXPLAIN, com.clougence.sql.mongodb.parser.ast.CmdKindType.READ);
+    EXPLAIN("explain", com.clougence.sql.mongodb.parser.ast.CommandType.EXPLAIN, com.clougence.sql.mongodb.parser.ast.CmdKindType.READ),
+    RS_STATUS("rs.status", com.clougence.sql.mongodb.parser.ast.CommandType.ADMIN_READ, com.clougence.sql.mongodb.parser.ast.CmdKindType.READ),
+    RS_CONF("rs.conf", com.clougence.sql.mongodb.parser.ast.CommandType.ADMIN_READ, com.clougence.sql.mongodb.parser.ast.CmdKindType.READ),
+    RS_REPLICATION_INFO("rs.printReplicationInfo", com.clougence.sql.mongodb.parser.ast.CommandType.ADMIN_READ, com.clougence.sql.mongodb.parser.ast.CmdKindType.READ),
+    SH_STATUS("sh.status", com.clougence.sql.mongodb.parser.ast.CommandType.ADMIN_READ, com.clougence.sql.mongodb.parser.ast.CmdKindType.READ),
+    SH_BALANCER_STATUS("sh.balancerStatus", com.clougence.sql.mongodb.parser.ast.CommandType.ADMIN_READ, com.clougence.sql.mongodb.parser.ast.CmdKindType.READ);
 
     @Getter
     private final String                                           funcStr;

--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/ast/commands/db/MongoAdminReadCommands.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/ast/commands/db/MongoAdminReadCommands.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.clougence.sql.mongodb.parser.ast.commands.db;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import com.clougence.sql.mongodb.parser.ast.MongoFuncType;
+import com.clougence.sql.mongodb.parser.ast.commands.AbstractMongoFunc;
+
+/**
+ * Read-only replica-set / sharding shell helpers mapped to runCommand payloads.
+ * Write/topology-changing helpers are intentionally unsupported here.
+ */
+public final class MongoAdminReadCommands {
+
+    private static final String ADMIN = "admin";
+    private static final String LOCAL = "local";
+
+    private static final Map<String, AbstractMongoFunc> RS_COMMANDS = new HashMap<>();
+    private static final Map<String, AbstractMongoFunc> SH_COMMANDS = new HashMap<>();
+
+    // Completion labels keep shell camelCase; resolve* still accepts any case.
+    private static final List<String> RS_METHODS = List.of(
+        "status",
+        "printSecondaryReplicationInfo",
+        "printSlaveReplicationInfo",
+        "conf",
+        "config",
+        "printReplicationInfo",
+        "getReplicationInfo",
+        "hello",
+        "isMaster"
+    );
+    private static final List<String> SH_METHODS = List.of(
+        "status",
+        "printShardingStatus",
+        "isBalancerRunning",
+        "getBalancerState",
+        "balancerStatus"
+    );
+
+    static {
+        MongoReadCommandFunc rsStatus = read(MongoFuncType.RS_STATUS, "{\"replSetGetStatus\":1}", ADMIN);
+        alias(RS_COMMANDS, rsStatus, "status", "printSecondaryReplicationInfo", "printSlaveReplicationInfo");
+
+        MongoReadCommandFunc rsConf = read(MongoFuncType.RS_CONF, "{\"replSetGetConfig\":1}", ADMIN);
+        alias(RS_COMMANDS, rsConf, "conf", "config");
+
+        MongoReadCommandFunc rsReplicationInfo = read(MongoFuncType.RS_REPLICATION_INFO, "{\"collStats\":\"oplog.rs\"}", LOCAL);
+        alias(RS_COMMANDS, rsReplicationInfo, "printReplicationInfo", "getReplicationInfo");
+
+        MongoReadCommandFunc isMaster = read(MongoFuncType.HELLO, "{\"isMaster\":1}", ADMIN);
+        alias(RS_COMMANDS, isMaster, "ismaster");
+
+        MongoReadCommandFunc shStatus = read(MongoFuncType.SH_STATUS, "{\"listShards\":1}", ADMIN);
+        alias(SH_COMMANDS, shStatus, "status", "printShardingStatus");
+
+        MongoReadCommandFunc balancerStatus = read(MongoFuncType.SH_BALANCER_STATUS, "{\"balancerStatus\":1}", ADMIN);
+        alias(SH_COMMANDS, balancerStatus, "isBalancerRunning", "getBalancerState", "balancerStatus");
+    }
+
+    private MongoAdminReadCommands(){
+    }
+
+    public static List<String> listRsMethods() {
+        return RS_METHODS;
+    }
+
+    public static List<String> listShMethods() {
+        return SH_METHODS;
+    }
+
+    public static AbstractMongoFunc resolveRs(String method) {
+        if ("hello".equalsIgnoreCase(method)) {
+            return new HelloFunc();
+        }
+        return RS_COMMANDS.get(normalize(method));
+    }
+
+    public static AbstractMongoFunc resolveSh(String method) {
+        return SH_COMMANDS.get(normalize(method));
+    }
+
+    private static MongoReadCommandFunc read(MongoFuncType funcType, String bson, String database) {
+        return new MongoReadCommandFunc(funcType, bson, database);
+    }
+
+    private static void alias(Map<String, AbstractMongoFunc> target, AbstractMongoFunc command, String... names) {
+        for (String name : names) {
+            target.put(normalize(name), command);
+        }
+    }
+
+    private static String normalize(String method) {
+        return method.toLowerCase(Locale.ROOT);
+    }
+}

--- a/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/ast/commands/db/MongoReadCommandFunc.java
+++ b/backend/clouddm-plugins/clouddm-sql/sql-mongodb/src/main/java/com/clougence/sql/mongodb/parser/ast/commands/db/MongoReadCommandFunc.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 杭州开云集致科技有限公司
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.clougence.sql.mongodb.parser.ast.commands.db;
+
+import com.clougence.sql.mongodb.parser.ast.MongoFuncType;
+import com.clougence.sql.mongodb.parser.ast.commands.AbstractMongoFunc;
+
+import lombok.Getter;
+
+@Getter
+public class MongoReadCommandFunc extends AbstractMongoFunc {
+
+    private final String bson;
+    private final String database;
+
+    public MongoReadCommandFunc(MongoFuncType funcType, String bson, String database){
+        this.funcType = funcType;
+        this.bson = bson;
+        this.database = database;
+    }
+
+    @Override
+    public MongoFuncType getFuncType() {
+        return this.funcType;
+    }
+
+    @Override
+    public String toBson() {
+        return this.bson;
+    }
+}


### PR DESCRIPTION
## Summary
- DBAs usually prefer running familiar `rs.*` / `sh.*` helpers in the query console, rather than rewriting them as `db.adminCommand({...})`.
- Add read-only replica-set and sharding shell helpers (e.g. `rs.status()`, `rs.conf()`, `sh.status()`, balancer status) mapped to the corresponding `runCommand` payloads.
- Wire parsing, execution, behavior/security classification, keywords, and `rs.` / `sh.` completion; write/topology-changing helpers remain unsupported.
- Note: `sh.status()` currently returns `listShards` result, not the full mongo shell formatted status.