### PR TITLE
SQL Work Order Workflow Template Display Issue

### DIFF
--- a/frontend/src/views/system/env.vue
+++ b/frontend/src/views/system/env.vue
@@ -985,7 +985,8 @@ export default {
 }
 
 .select-wrap {
-  :deep(.ivu-select-dropdown) {
+  :deep(.ivu-select-dropdown),
+  :deep(.ivu-select-dropdown-list) {
     max-height: 200px !important;
   }
 }


### PR DESCRIPTION
Fix the issue where the dropdown displays a maximum of 6 workflow templates when configuring SQL work orders in the environment list.