### PR TITLE
fix(frontend): bind antd form controls with v-model:value

### DIFF
--- a/frontend/src/views/sql/components/DataSourceTree.vue
+++ b/frontend/src/views/sql/components/DataSourceTree.vue
@@ -1470,7 +1470,7 @@ export default {
       <div style="margin-bottom: 5px; font-weight: bold">
         {{ $t('xiu-gai-selectednodepoptip-de-bei-zhu-selectednodetitle-wei', [selectedNode.popTip, selectedNode.title]) }}
       </div>
-      <a-input v-model="dsDesc" :placeholder="$t('qing-shu-ru-xin-de-bei-zhu')" allow-clear />
+      <a-input v-model:value="dsDesc" :placeholder="$t('qing-shu-ru-xin-de-bei-zhu')" allow-clear />
       <template #footer>
         <a-button @click="handleRightClickMenu(actionType)">{{ $t('xiu-gai') }}</a-button>
         <a-button @click="handleCloseModal">{{ $t('guan-bi') }}</a-button>

--- a/frontend/src/views/sql/components/TableList.vue
+++ b/frontend/src/views/sql/components/TableList.vue
@@ -606,7 +606,7 @@
               </a-tooltip>
             </div>
             <div class="option">
-              <a-checkbox v-model="genDataModal.globalConfigs.ignoreErrors">
+              <a-checkbox v-model:checked="genDataModal.globalConfigs.ignoreErrors">
                 {{ $t('yu-dao-cuo-wu-shi-ji-xu') }}
               </a-checkbox>
               <a-tooltip placement="bottom" style="margin-left: 3px; margin-right: 5px">
@@ -933,10 +933,10 @@
     <CCModal v-model="showTicketModal" :title="$t('ti-jiao-gong-dan')" @cancel="showTicketModal = false" @ok="showTicketModal = false">
       <a-form :model="ticketData" :rules="ticketRuleValidate" ref="ticketContent" :label-col="{ span: 4 }" :wrapper-col="{ span: 20 }">
         <a-form-item :label="$t('biao-ti')" prop="ticketTitle">
-          <a-input v-model="ticketData.ticketTitle" />
+          <a-input v-model:value="ticketData.ticketTitle" />
         </a-form-item>
         <a-form-item :label="$t('xu-qiu-miao-shu')" prop="description">
-          <a-input type="textarea" v-model="ticketData.description" :rows="4" />
+          <a-textarea v-model:value="ticketData.description" :rows="4" />
         </a-form-item>
       </a-form>
       <template #footer>


### PR DESCRIPTION
Why:
Submitting a delete-table ticket failed with "description cannot be empty"
even though the description had been filled in. Ant Design Vue form
controls only accept the value prop, so a plain v-model (modelValue) never
wrote user input back to the form model — the model kept its initial empty
string and validation rejected the input.

What:
- Bind the ticket title and description with v-model:value and use
  a-textarea for the description field, aligning with the working ticket
  form in StructView.
- Fix the instance remark input in DataSourceTree that silently discarded
  user input for the same reason.
- Fix the generate-data "continue on error" checkbox with v-model:checked.